### PR TITLE
Use @bs.obj and remove internal_cleanObjectFromUndefinedRaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - _BREAKING CHANGE_ Replace `ReactDOMRe.Experimental.createRoot` with `ReactDOMExperimental.unstable_createRoot` [#121](https://github.com/zth/reason-relay/pull/121) ([@sorenhoyer](https://github.com/sorenhoyer))
 - _BREAKING CHANGE_ Remove `Query.fetchPromised`. Users can convert the fetch to a promise themselves if needed. ([@zth](https://github.com/zth))
 - _BREAKING CHANGE_ Remove `Mutation.commitMutationPromised`. Users can convert the mutation to a promise themselves if needed. ([@zth](https://github.com/zth))
+- _BREAKING CHANGE_ Use @bs.obj for (refetch)variables instead of records [#124](https://github.com/zth/reason-relay/pull/124) ([@tsnobip](https://github.com/tsnobip))
 
 ## New bindings
 
@@ -27,6 +28,7 @@
 - Add support for parsing ReScript (.res) files [#115](https://github.com/zth/reason-relay/pull/115) ([@sorenhoyer](https://github.com/sorenhoyer))
 - Move a bunch of things from the bindings to the PPX. This will simplify a lot of things, improve the type safety some, and pave the way for some pretty interesting upcoming editor tooling. ([@zth](https://github.com/zth))
 - Remove `internal_cleanVariablesRaw`, since `bs-platform` since `7.3` does what that did by default. ([@zth](https://github.com/zth))
+- Remove `ReasonRelay_Internal.internal_cleanObjectFromUndefinedRaw` since variables are made with @bs.obj where undefined fields are absent [#124](https://github.com/zth/reason-relay/pull/124) ([@tsnobip](https://github.com/tsnobip))
 
 # 0.11.0
 

--- a/packages/reason-relay/__tests__/Test_customScalars.re
+++ b/packages/reason-relay/__tests__/Test_customScalars.re
@@ -23,7 +23,11 @@ module Test = {
   let make = () => {
     let query =
       Query.use(
-        ~variables={beforeDate: Some(Js.Date.fromFloat(1514764800000.))},
+        ~variables=
+          Query.makeVariables(
+            ~beforeDate=Js.Date.fromFloat(1514764800000.),
+            (),
+          ),
         (),
       );
 

--- a/packages/reason-relay/__tests__/Test_mutation.re
+++ b/packages/reason-relay/__tests__/Test_mutation.re
@@ -188,7 +188,7 @@ module Test = {
           let _ =
             Mutation.commitMutation(
               ~environment,
-              ~variables={onlineStatus: `Idle},
+              ~variables=Mutation.makeVariables(~onlineStatus=`Idle),
               ~updater=
                 (store, response) =>
                   switch (

--- a/packages/reason-relay/__tests__/Test_paginationInNode.re
+++ b/packages/reason-relay/__tests__/Test_paginationInNode.re
@@ -68,8 +68,7 @@ module UserDisplayer = {
 module UserNodeDisplayer = {
   [@react.component]
   let make = (~queryRef) => {
-    let (startTransition, _) =
-      ReactExperimental.unstable_useTransition();
+    let (startTransition, _) = ReactExperimental.unstable_useTransition();
 
     let {data, hasNext, loadNext, isLoadingNext, refetch} =
       Fragment.usePagination(queryRef);
@@ -126,7 +125,7 @@ module Test = {
   [@react.component]
   let make = () => {
     let userId = "123";
-    let query = Query.use(~variables={userId: userId}, ());
+    let query = Query.use(~variables=Query.makeVariables(~userId), ());
     switch (query.node) {
     | Some(node) => <UserNodeDisplayer queryRef={node.fragmentRefs} />
     | None => React.string("-")

--- a/packages/reason-relay/__tests__/Test_paginationUnion.re
+++ b/packages/reason-relay/__tests__/Test_paginationUnion.re
@@ -80,10 +80,9 @@ module Test = {
   [@react.component]
   let make = () => {
     let groupId = "123";
-    let query = Query.use(~variables={groupId: groupId}, ());
+    let query = Query.use(~variables=Query.makeVariables(~groupId), ());
 
-    let (startTransition, _) =
-      ReactExperimental.unstable_useTransition();
+    let (startTransition, _) = ReactExperimental.unstable_useTransition();
 
     let {data, hasNext, loadNext, isLoadingNext, refetch} =
       Fragment.usePagination(query.fragmentRefs);

--- a/packages/reason-relay/__tests__/Test_query.re
+++ b/packages/reason-relay/__tests__/Test_query.re
@@ -78,7 +78,7 @@ module Test = {
       | _ => [||]
       };
 
-    let query = Query.use(~variables={status: status}, ());
+    let query = Query.use(~variables=Query.makeVariables(~status?, ()), ());
     let users = collectUsers(query);
 
     <div>
@@ -113,7 +113,7 @@ module Test = {
             Some(
               TestQuery_graphql.load(
                 ~environment,
-                ~variables={status: Some(`Idle)},
+                ~variables=Query.makeVariables(~status=`Idle, ()),
                 (),
               ),
             )
@@ -126,7 +126,7 @@ module Test = {
           let queryRef =
             TestQuery_graphql.load(
               ~environment,
-              ~variables={status: Some(`Idle)},
+              ~variables=Query.makeVariables(~status=`Idle, ()),
               (),
             );
 
@@ -147,7 +147,7 @@ module Test = {
         onClick={_ =>
           Query.fetch(
             ~environment,
-            ~variables={status: Some(`Online)},
+            ~variables=Query.makeVariables(~status=`Online, ()),
             ~onResult=
               fun
               | Ok(res) => setFetchedResult(_ => Some(collectUsers(res)))
@@ -158,7 +158,9 @@ module Test = {
         {React.string("Test fetch")}
       </button>
       <button
-        onClick={_ => loadQuery(~variables={status: Some(`Idle)}, ())}>
+        onClick={_ =>
+          loadQuery(~variables=Query.makeVariables(~status=`Idle, ()), ())
+        }>
         {React.string("Test query loader")}
       </button>
       {hasWaitedForPreload

--- a/packages/reason-relay/__tests__/Test_refetchingInNode.re
+++ b/packages/reason-relay/__tests__/Test_refetchingInNode.re
@@ -33,8 +33,7 @@ module UserDisplayer = {
   let make = (~queryRef) => {
     let (data, refetch) = Fragment.useRefetchable(queryRef);
 
-    let (startTransition, _) =
-      ReactExperimental.unstable_useTransition();
+    let (startTransition, _) = ReactExperimental.unstable_useTransition();
 
     <div>
       {React.string(
@@ -73,7 +72,8 @@ module UserDisplayer = {
 module Test = {
   [@react.component]
   let make = () => {
-    let query = Query.use(~variables={userId: "user-1"}, ());
+    let query =
+      Query.use(~variables=Query.makeVariables(~userId="user-1"), ());
 
     switch (query.node) {
     | Some(user) => <UserDisplayer queryRef={user.fragmentRefs} />

--- a/packages/reason-relay/__tests__/Test_subscription.re
+++ b/packages/reason-relay/__tests__/Test_subscription.re
@@ -44,7 +44,7 @@ module Test = {
       let disposable =
         UserUpdatedSubscription.subscribe(
           ~environment,
-          ~variables={userId: "user-1"},
+          ~variables=UserUpdatedSubscription.makeVariables(~userId="user-1"),
           ~updater=
             (store, response) => {
               switch (

--- a/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestCustomScalarsQuery_graphql.re
@@ -21,11 +21,12 @@ module Types = {
       ),
   };
   type rawResponse = response;
-  type refetchVariables = {beforeDate: option(TestsUtils.Datetime.t)};
-  let makeRefetchVariables = (~beforeDate=?, ()): refetchVariables => {
-    beforeDate: beforeDate,
-  };
-  type variables = {beforeDate: option(TestsUtils.Datetime.t)};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (~beforeDate: TestsUtils.Datetime.t=?, unit) => refetchVariables =
+    "";
+  type variables;
 };
 
 let unwrap_response_member:
@@ -102,9 +103,10 @@ type queryRef;
 
 module Utils = {
   open Types;
-  let makeVariables = (~beforeDate=?, ()): variables => {
-    beforeDate: beforeDate,
-  };
+  [@bs.obj]
+  external makeVariables:
+    (~beforeDate: TestsUtils.Datetime.t=?, unit) => variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.re
@@ -17,7 +17,7 @@ module Types = {
     setOnlineStatusComplex: option(response_setOnlineStatusComplex),
   };
   type rawResponse = response;
-  type variables = {input: setOnlineStatusInput};
+  type variables;
 };
 
 module Internal = {
@@ -74,7 +74,8 @@ module Utils = {
     onlineStatus: onlineStatus,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: setOnlineStatusInput) => variables = "";
 
   let make_response_setOnlineStatusComplex_user =
       (~id, ~onlineStatus=?, ()): response_setOnlineStatusComplex_user => {

--- a/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.re
@@ -23,7 +23,7 @@ module Types = {
 
   type response = {setOnlineStatus: option(response_setOnlineStatus)};
   type rawResponse = {setOnlineStatus: option(rawResponse_setOnlineStatus)};
-  type variables = {onlineStatus: enum_OnlineStatus};
+  type variables;
 };
 
 module Internal = {
@@ -96,9 +96,8 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables = (~onlineStatus): variables => {
-    onlineStatus: onlineStatus,
-  };
+  [@bs.obj]
+  external makeVariables: (~onlineStatus: enum_OnlineStatus) => variables = "";
 
   let make_rawResponse_setOnlineStatus_user =
       (~id, ~onlineStatus=?, ~firstName, ~lastName, ())

--- a/packages/reason-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.re
@@ -20,7 +20,7 @@ module Types = {
 
   type response = {setOnlineStatus: option(response_setOnlineStatus)};
   type rawResponse = {setOnlineStatus: option(rawResponse_setOnlineStatus)};
-  type variables = {onlineStatus: enum_OnlineStatus};
+  type variables;
 };
 
 module Internal = {
@@ -93,9 +93,8 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables = (~onlineStatus): variables => {
-    onlineStatus: onlineStatus,
-  };
+  [@bs.obj]
+  external makeVariables: (~onlineStatus: enum_OnlineStatus) => variables = "";
 
   let make_rawResponse_setOnlineStatus_user =
       (~id, ~firstName, ~lastName, ~onlineStatus=?, ())

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeQuery_graphql.re
@@ -10,11 +10,11 @@ module Types = {
 
   type response = {node: option(response_node)};
   type rawResponse = response;
-  type refetchVariables = {userId: option(string)};
-  let makeRefetchVariables = (~userId=?, ()): refetchVariables => {
-    userId: userId,
-  };
-  type variables = {userId: string};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables: (~userId: string=?, unit) => refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -67,7 +67,7 @@ type queryRef;
 
 module Utils = {
   open Types;
-  let makeVariables = (~userId): variables => {userId: userId};
+  [@bs.obj] external makeVariables: (~userId: string) => variables = "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.re
@@ -10,25 +10,19 @@ module Types = {
 
   type response = {node: option(response_node)};
   type rawResponse = response;
-  type refetchVariables = {
-    count: option(int),
-    cursor: option(string),
-    onlineStatuses: option(array(enum_OnlineStatus)),
-    id: option(string),
-  };
-  let makeRefetchVariables =
-      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id=?, ()): refetchVariables => {
-    count,
-    cursor,
-    onlineStatuses,
-    id,
-  };
-  type variables = {
-    count: option(int),
-    cursor: option(string),
-    onlineStatuses: option(array(enum_OnlineStatus)),
-    id: string,
-  };
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (
+      ~count: int=?,
+      ~cursor: string=?,
+      ~onlineStatuses: array(enum_OnlineStatus)=?,
+      ~id: string=?,
+      unit
+    ) =>
+    refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -83,13 +77,17 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables =
-      (~count=?, ~cursor=?, ~onlineStatuses=?, ~id, ()): variables => {
-    count,
-    cursor,
-    onlineStatuses,
-    id,
-  };
+  [@bs.obj]
+  external makeVariables:
+    (
+      ~count: int=?,
+      ~cursor: string=?,
+      ~onlineStatuses: array(enum_OnlineStatus)=?,
+      ~id: string,
+      unit
+    ) =>
+    variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionQuery_graphql.re
@@ -7,11 +7,11 @@ module Types = {
     fragmentRefs: ReasonRelay.fragmentRefs([ | `TestPaginationUnion_query]),
   };
   type rawResponse = response;
-  type refetchVariables = {groupId: option(string)};
-  let makeRefetchVariables = (~groupId=?, ()): refetchVariables => {
-    groupId: groupId,
-  };
-  type variables = {groupId: string};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables: (~groupId: string=?, unit) => refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -64,7 +64,7 @@ type queryRef;
 
 module Utils = {
   open Types;
-  let makeVariables = (~groupId): variables => {groupId: groupId};
+  [@bs.obj] external makeVariables: (~groupId: string) => variables = "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.re
@@ -9,26 +9,19 @@ module Types = {
     fragmentRefs: ReasonRelay.fragmentRefs([ | `TestPaginationUnion_query]),
   };
   type rawResponse = response;
-  type refetchVariables = {
-    count: option(int),
-    cursor: option(string),
-    groupId: option(string),
-    onlineStatuses: option(array(enum_OnlineStatus)),
-  };
-  let makeRefetchVariables =
-      (~count=?, ~cursor=?, ~groupId=?, ~onlineStatuses=?, ())
-      : refetchVariables => {
-    count,
-    cursor,
-    groupId,
-    onlineStatuses,
-  };
-  type variables = {
-    count: option(int),
-    cursor: option(string),
-    groupId: string,
-    onlineStatuses: option(array(enum_OnlineStatus)),
-  };
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (
+      ~count: int=?,
+      ~cursor: string=?,
+      ~groupId: string=?,
+      ~onlineStatuses: array(enum_OnlineStatus)=?,
+      unit
+    ) =>
+    refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -83,13 +76,17 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables =
-      (~count=?, ~cursor=?, ~groupId, ~onlineStatuses=?, ()): variables => {
-    count,
-    cursor,
-    groupId,
-    onlineStatuses,
-  };
+  [@bs.obj]
+  external makeVariables:
+    (
+      ~count: int=?,
+      ~cursor: string=?,
+      ~groupId: string,
+      ~onlineStatuses: array(enum_OnlineStatus)=?,
+      unit
+    ) =>
+    variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestQuery_graphql.re
@@ -16,11 +16,12 @@ module Types = {
 
   type response = {users: option(response_users)};
   type rawResponse = response;
-  type refetchVariables = {status: option(enum_OnlineStatus)};
-  let makeRefetchVariables = (~status=?, ()): refetchVariables => {
-    status: status,
-  };
-  type variables = {status: option(enum_OnlineStatus)};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (~status: enum_OnlineStatus=?, unit) => refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -75,7 +76,9 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables = (~status=?, ()): variables => {status: status};
+  [@bs.obj]
+  external makeVariables: (~status: enum_OnlineStatus=?, unit) => variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.re
@@ -9,11 +9,11 @@ module Types = {
 
   type response = {node: option(response_node)};
   type rawResponse = response;
-  type refetchVariables = {userId: option(string)};
-  let makeRefetchVariables = (~userId=?, ()): refetchVariables => {
-    userId: userId,
-  };
-  type variables = {userId: string};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables: (~userId: string=?, unit) => refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -66,7 +66,7 @@ type queryRef;
 
 module Utils = {
   open Types;
-  let makeVariables = (~userId): variables => {userId: userId};
+  [@bs.obj] external makeVariables: (~userId: string) => variables = "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.re
@@ -10,23 +10,18 @@ module Types = {
 
   type response = {node: option(response_node)};
   type rawResponse = response;
-  type refetchVariables = {
-    friendsOnlineStatuses: option(array(enum_OnlineStatus)),
-    showOnlineStatus: option(bool),
-    id: option(string),
-  };
-  let makeRefetchVariables =
-      (~friendsOnlineStatuses=?, ~showOnlineStatus=?, ~id=?, ())
-      : refetchVariables => {
-    friendsOnlineStatuses,
-    showOnlineStatus,
-    id,
-  };
-  type variables = {
-    friendsOnlineStatuses: array(enum_OnlineStatus),
-    showOnlineStatus: bool,
-    id: string,
-  };
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (
+      ~friendsOnlineStatuses: array(enum_OnlineStatus)=?,
+      ~showOnlineStatus: bool=?,
+      ~id: string=?,
+      unit
+    ) =>
+    refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -81,12 +76,15 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables =
-      (~friendsOnlineStatuses, ~showOnlineStatus, ~id): variables => {
-    friendsOnlineStatuses,
-    showOnlineStatus,
-    id,
-  };
+  [@bs.obj]
+  external makeVariables:
+    (
+      ~friendsOnlineStatuses: array(enum_OnlineStatus),
+      ~showOnlineStatus: bool,
+      ~id: string
+    ) =>
+    variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.re
@@ -10,23 +10,18 @@ module Types = {
 
   type response = {node: option(response_node)};
   type rawResponse = response;
-  type refetchVariables = {
-    friendsOnlineStatuses: option(array(enum_OnlineStatus)),
-    showOnlineStatus: option(bool),
-    id: option(string),
-  };
-  let makeRefetchVariables =
-      (~friendsOnlineStatuses=?, ~showOnlineStatus=?, ~id=?, ())
-      : refetchVariables => {
-    friendsOnlineStatuses,
-    showOnlineStatus,
-    id,
-  };
-  type variables = {
-    friendsOnlineStatuses: option(array(enum_OnlineStatus)),
-    showOnlineStatus: bool,
-    id: string,
-  };
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables:
+    (
+      ~friendsOnlineStatuses: array(enum_OnlineStatus)=?,
+      ~showOnlineStatus: bool=?,
+      ~id: string=?,
+      unit
+    ) =>
+    refetchVariables =
+    "";
+  type variables;
 };
 
 module Internal = {
@@ -81,12 +76,16 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables =
-      (~friendsOnlineStatuses=?, ~showOnlineStatus, ~id, ()): variables => {
-    friendsOnlineStatuses,
-    showOnlineStatus,
-    id,
-  };
+  [@bs.obj]
+  external makeVariables:
+    (
+      ~friendsOnlineStatuses: array(enum_OnlineStatus)=?,
+      ~showOnlineStatus: bool,
+      ~id: string,
+      unit
+    ) =>
+    variables =
+    "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.re
+++ b/packages/reason-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.re
@@ -13,7 +13,7 @@ module Types = {
 
   type response = {userUpdated: option(response_userUpdated)};
   type rawResponse = response;
-  type variables = {userId: string};
+  type variables;
 };
 
 module Internal = {
@@ -50,7 +50,7 @@ module Utils = {
   external onlineStatus_toString: Types.enum_OnlineStatus => string =
     "%identity";
   open Types;
-  let makeVariables = (~userId): variables => {userId: userId};
+  [@bs.obj] external makeVariables: (~userId: string) => variables = "";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/language-plugin/src/__tests__/__snapshots__/languagePlugin-tests.ts.snap
+++ b/packages/reason-relay/language-plugin/src/__tests__/__snapshots__/languagePlugin-tests.ts.snap
@@ -38,7 +38,7 @@ module Types = {
 
   type response = {mutationWithReservedName: bool};
   type rawResponse = response;
-  type variables = {input: mutationWithReservedNameInput};
+  type variables;
 };
 
 module Internal = {
@@ -96,7 +96,9 @@ module Utils = {
     nested,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: mutationWithReservedNameInput) => variables =
+    \\"\\";
 
   let makeOptimisticResponse = (~mutationWithReservedName): rawResponse => {
     mutationWithReservedName: mutationWithReservedName,
@@ -266,7 +268,7 @@ module Types = {
 
   type response = {setUserLocation: response_setUserLocation};
   type rawResponse = response;
-  type variables = {input: setUserLocationInput};
+  type variables;
 };
 
 module Internal = {
@@ -331,7 +333,8 @@ module Utils = {
     location,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: setUserLocationInput) => variables = \\"\\";
 
   let make_response_setUserLocation_changedUser =
       (~id, ~firstName, ~role): response_setUserLocation_changedUser => {
@@ -379,7 +382,7 @@ module Types = {
 
   type response = {setUserLocation: response_setUserLocation};
   type rawResponse = response;
-  type variables = {input: setUserLocationInput};
+  type variables;
 };
 
 module Internal = {
@@ -443,7 +446,8 @@ module Utils = {
     location,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: setUserLocationInput) => variables = \\"\\";
 
   let make_response_setUserLocation_changedUser = () =>
     [@ocaml.warning \\"-27\\"] {};
@@ -534,7 +538,7 @@ module Types = {
 
   type response = {setUserLocation: response_setUserLocation};
   type rawResponse = response;
-  type variables = {input: setUserLocationInput};
+  type variables;
 };
 
 module Internal = {
@@ -598,7 +602,8 @@ module Utils = {
     location,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: setUserLocationInput) => variables = \\"\\";
 
   let make_response_setUserLocation_changedUser =
       (~id, ~firstName): response_setUserLocation_changedUser => {
@@ -978,11 +983,11 @@ module Types = {
 
   type response = {user: option(response_user)};
   type rawResponse = response;
-  type refetchVariables = {userId: option(string)};
-  let makeRefetchVariables = (~userId=?, ()): refetchVariables => {
-    userId: userId,
-  };
-  type variables = {userId: string};
+  type refetchVariables;
+  [@bs.obj]
+  external makeRefetchVariables: (~userId: string=?, unit) => refetchVariables =
+    \\"\\";
+  type variables;
 };
 
 module Internal = {
@@ -1035,7 +1040,7 @@ type queryRef;
 
 module Utils = {
   open Types;
-  let makeVariables = (~userId): variables => {userId: userId};
+  [@bs.obj] external makeVariables: (~userId: string) => variables = \\"\\";
 };
 
 type relayOperationNode;
@@ -1062,7 +1067,7 @@ module Types = {
 
   type response = {userChanged: response_userChanged};
   type rawResponse = response;
-  type variables = {input: userChangedInput};
+  type variables;
 };
 
 module Internal = {
@@ -1103,7 +1108,8 @@ module Utils = {
     userId,
   };
 
-  let makeVariables = (~input): variables => {input: input};
+  [@bs.obj]
+  external makeVariables: (~input: userChangedInput) => variables = \\"\\";
 };
 
 type relayOperationNode;

--- a/packages/reason-relay/language-plugin/src/transformer/PrintState.re
+++ b/packages/reason-relay/language-plugin/src/transformer/PrintState.re
@@ -384,7 +384,8 @@ let getPrintedFullState =
     variables->Printer.objHasPrintableContents
       ? {
         variables
-        ->Printer.printObjectMaker(
+        ->Printer.printInputObjectMaker(
+            ~state,
             ~targetType="variables",
             ~name="makeVariables",
           )

--- a/packages/reason-relay/reason-relay-ppx/library/Fragment.re
+++ b/packages/reason-relay/reason-relay-ppx/library/Fragment.re
@@ -253,8 +253,7 @@ let make =
                           ~moduleName=queryName,
                           ["Internal", "convertVariables"],
                         )
-                      ]
-                    ->ReasonRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+                      ],
                     InternalRefetch.internal_makeRefetchableFnOpts(
                       ~fetchPolicy?,
                       ~renderPolicy?,
@@ -398,8 +397,7 @@ let make =
                         ~moduleName=queryName,
                         ["Internal", "convertVariables"],
                       )
-                    ]
-                  ->ReasonRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+                    ],
                   InternalRefetch.internal_makeRefetchableFnOpts(
                     ~onComplete?,
                     ~fetchPolicy?,
@@ -471,8 +469,7 @@ let make =
                         ~moduleName=queryName,
                         ["Internal", "convertVariables"],
                       )
-                    ]
-                  ->ReasonRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+                    ],
                   InternalRefetch.internal_makeRefetchableFnOpts(
                     ~onComplete?,
                     ~fetchPolicy?,

--- a/packages/reason-relay/reason-relay-ppx/library/Query.re
+++ b/packages/reason-relay/reason-relay-ppx/library/Query.re
@@ -110,8 +110,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
             Internal.internal_useQuery(
               [%e valFromGeneratedModule(["node"])],
               variables
-              ->[%e valFromGeneratedModule(["Internal", "convertVariables"])]
-              ->ReasonRelay_Internal.internal_cleanObjectFromUndefinedRaw,
+              ->[%e valFromGeneratedModule(["Internal", "convertVariables"])],
               {
                 fetchKey,
                 fetchPolicy: fetchPolicy->ReasonRelay.mapFetchPolicy,

--- a/packages/reason-relay/src/ReasonRelay.re
+++ b/packages/reason-relay/src/ReasonRelay.re
@@ -1,5 +1,5 @@
 type arguments;
-type allFieldsMasked = {.};
+type allFieldsMasked = Js.t({.});
 
 type any;
 

--- a/packages/reason-relay/src/ReasonRelay.rei
+++ b/packages/reason-relay/src/ReasonRelay.rei
@@ -1,5 +1,5 @@
 type arguments;
-type allFieldsMasked = {.};
+type allFieldsMasked = Js.t({.});
 
 /**
  * Abstract helper type to signify something that could not be

--- a/packages/reason-relay/src/ReasonRelay_Internal.re
+++ b/packages/reason-relay/src/ReasonRelay_Internal.re
@@ -2,27 +2,6 @@
  * Various helpers.
  */
 
-// We occasionally have to remove undefined keys from objects, something I haven't figured out how to do with pure BuckleScript
-let internal_cleanObjectFromUndefinedRaw = [%raw
-  {|
-  function (obj) {
-    if (!obj) {
-      return obj;
-    }
-
-    var newObj = {};
-
-    Object.keys(obj).forEach(function(key) {
-      if (typeof obj[key] !== 'undefined') {
-        newObj[key] = obj[key];
-      }
-    });
-
-    return newObj;
-  }
-|}
-];
-
 let internal_useConvertedValue = (convert, v) =>
   React.useMemo1(() => convert(v), [|v|]);
 

--- a/packages/reason-relay/src/ReasonRelay_Internal.rei
+++ b/packages/reason-relay/src/ReasonRelay_Internal.rei
@@ -3,6 +3,5 @@
  */
 
 let internal_useConvertedValue: ('a => 'a, 'a) => 'a;
-let internal_cleanObjectFromUndefinedRaw: 't => 't;
 let internal_nullableToOptionalExnHandler:
   option(option('b) => 'a) => option(Js.Nullable.t('b) => 'a);


### PR DESCRIPTION
This PR shows how you can use @bs.obj instead of records to model `variables` and `refetchVariables`, which makes undefined fields absent and remove the need for `ReasonRelayt_Internal.internal_cleanObjectFromUndefinedRaw`.

It's a breaking change since you can't use a record to construct `variables` and `refetchVariables` anymore.

For a better API maybe we could generate hooks directly with the different fields of the variables?