### PR TITLE
Offload importing nodes in refetch queries to bsb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+- Support ES6 imports for `@refetchable` queries
+
 # 0.17.1
 
 Small patch release, mainly fixing the broken `getConnectionID` binding.

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
@@ -62,6 +62,7 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
+let node_TestPaginationInNodeRefetchQuery = TestPaginationInNodeRefetchQuery.node;
 let node: operationType = %raw(json` (function(){
 var v0 = [
   "friendsConnection"
@@ -113,7 +114,7 @@ return {
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": require('./TestPaginationInNodeRefetchQuery_graphql.bs.js').node,
+      "operation": node_TestPaginationInNodeRefetchQuery,
       "identifierField": "id"
     }
   },

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
@@ -120,6 +120,7 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
+let node_TestPaginationUnionRefetchQuery = TestPaginationUnionRefetchQuery.node;
 let node: operationType = %raw(json` (function(){
 var v0 = [
   "members"
@@ -174,7 +175,7 @@ return {
         "path": (v0/*: any*/)
       },
       "fragmentPathInResult": [],
-      "operation": require('./TestPaginationUnionRefetchQuery_graphql.bs.js').node
+      "operation": node_TestPaginationUnionRefetchQuery
     }
   },
   "name": "TestPaginationUnion_query",

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
@@ -58,6 +58,7 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
+let node_TestRefetchingInNodeRefetchQuery = TestRefetchingInNodeRefetchQuery.node;
 let node: operationType = %raw(json` {
   "argumentDefinitions": [
     {
@@ -81,7 +82,7 @@ let node: operationType = %raw(json` {
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": require('./TestRefetchingInNodeRefetchQuery_graphql.bs.js').node,
+      "operation": node_TestRefetchingInNodeRefetchQuery,
       "identifierField": "id"
     }
   },

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
@@ -58,6 +58,7 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
+let node_TestRefetchingRefetchQuery = TestRefetchingRefetchQuery.node;
 let node: operationType = %raw(json` {
   "argumentDefinitions": [
     {
@@ -78,7 +79,7 @@ let node: operationType = %raw(json` {
       "fragmentPathInResult": [
         "node"
       ],
-      "operation": require('./TestRefetchingRefetchQuery_graphql.bs.js').node,
+      "operation": node_TestRefetchingRefetchQuery,
       "identifierField": "id"
     }
   },

--- a/packages/rescript-relay/language-plugin/src/formatGeneratedModule.ts
+++ b/packages/rescript-relay/language-plugin/src/formatGeneratedModule.ts
@@ -4,12 +4,8 @@ import { processConcreteText } from "./utils/processConcreteText";
 const formatGeneratedModule: FormatModule = ({
   moduleName,
   documentType,
-  docText,
   concreteText,
   typeText,
-  kind,
-  hash,
-  sourceHash,
 }) => {
   const preloadText =
     // @ts-ignore The type definitions are actually wrong from DefinitivelyTyped
@@ -24,12 +20,20 @@ const formatGeneratedModule: FormatModule = ({
     let convertVariables = Internal.convertVariables
   });`
       : "";
+  const { processedText, referencedNodes } = processConcreteText(concreteText);
 
-  return `${typeText || ""}
-let node: operationType = %raw(json\` ${processConcreteText(concreteText)} \`)
-
-${preloadText}
-`;
+  const lines = [
+    typeText || "",
+    ...referencedNodes
+      .map(
+        ({ moduleName, identifier }) => `let ${identifier} = ${moduleName}.node;`
+      ),
+    `let node: operationType = %raw(json\` ${processedText} \`)`,
+    "",
+    preloadText,
+    ""
+  ];
+  return lines.join("\n");
 };
 
 module.exports = formatGeneratedModule;

--- a/packages/rescript-relay/language-plugin/src/utils/__tests__/processConcreteText-tests.ts
+++ b/packages/rescript-relay/language-plugin/src/utils/__tests__/processConcreteText-tests.ts
@@ -7,9 +7,19 @@ describe("processConcreteText", () => {
         ` "operation": require('./BookDisplayerRefetchQuery.graphql.re'),
         "someOtherOp": require('./SomeRefetchQuery.graphql.re'),`
       )
-    ).toBe(
-      ` "operation": require('./BookDisplayerRefetchQuery_graphql.bs.js').node,
-        "someOtherOp": require('./SomeRefetchQuery_graphql.bs.js').node,`
-    );
+    ).toStrictEqual({
+      processedText: ` "operation": node_BookDisplayerRefetchQuery,
+        "someOtherOp": node_SomeRefetchQuery,`,
+      referencedNodes: [
+        {
+          identifier: "node_BookDisplayerRefetchQuery",
+          moduleName: "BookDisplayerRefetchQuery",
+        },
+        {
+          identifier: "node_SomeRefetchQuery",
+          moduleName: "SomeRefetchQuery",
+        },
+      ],
+    });
   });
 });

--- a/packages/rescript-relay/language-plugin/src/utils/processConcreteText.ts
+++ b/packages/rescript-relay/language-plugin/src/utils/processConcreteText.ts
@@ -8,16 +8,29 @@
  *   be working fine.
  */
 
-export function processConcreteText(concreteText: string): string {
+type ReferencedNode = {
+  identifier: string;
+  moduleName: string;
+}
+
+type Result = {
+  processedText: string;
+  referencedNodes: ReferencedNode[];
+}
+
+export function processConcreteText(concreteText: string): Result {
   let requireRegexp = /(require\('.\/)([A-Za-z_.0-9/]+)(.graphql.\w*'\))/gm;
   let str = concreteText;
+  const referencedNodes: ReferencedNode[] = [];
 
   let result;
 
   while ((result = requireRegexp.exec(concreteText)) !== null) {
     let [fullStr, _, moduleName] = result;
-    str = str.replace(fullStr, `require('./${moduleName}_graphql.bs.js').node`);
+    const identifier = `node_${moduleName}`;
+    referencedNodes.push({moduleName, identifier});
+    str = str.replace(fullStr, identifier);
   }
 
-  return str;
+  return { processedText: str, referencedNodes };
 }


### PR DESCRIPTION
relay compiler generates require calls which break
es6 builds. By offloading importing to bsb we can
support both es6 and commonjs transparently and easily