### PR TITLE
remove warnings for unused values, types, modules

### DIFF
--- a/packages/rescript-relay/__tests__/Test_mutation.resi
+++ b/packages/rescript-relay/__tests__/Test_mutation.resi
@@ -1,0 +1,1 @@
+let test_mutation: unit => React.element

--- a/packages/rescript-relay/__tests__/Test_subscription.resi
+++ b/packages/rescript-relay/__tests__/Test_subscription.resi
@@ -1,0 +1,5 @@
+let test_subscription: unit => {
+  "getSink": unit => option<RescriptRelay.Observable.sink<Js.Json.t>>,
+  "render": unit => React.element,
+  "subscriptionFunction": ('b, 'c, 'd) => RescriptRelay.Observable.t<Js.Json.t>,
+}

--- a/packages/rescript-relay/bsconfig.json
+++ b/packages/rescript-relay/bsconfig.json
@@ -22,11 +22,16 @@
   "ppx-flags": [
     "./rescript-relay-ppx/_esy/default/build/default/bin/RescriptRelayPpxApp.exe"
   ],
-  "bs-dependencies": ["@rescript/react", "reason-promise"],
-  "bs-dev-dependencies": ["bs-fetch"],
+  "bs-dependencies": [
+    "@rescript/react",
+    "reason-promise"
+  ],
+  "bs-dev-dependencies": [
+    "bs-fetch"
+  ],
   "suffix": ".bs.js",
   "warnings": {
-    "error": "+101"
+    "error": "+A+101"
   },
   "refmt": 3
 }

--- a/packages/rescript-relay/rescript-relay-ppx/library/FragmentUtils.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/FragmentUtils.re
@@ -1,7 +1,7 @@
 open Ppxlib;
 
 let makeGeneratedModuleImports = (~loc, ~moduleIdentFromGeneratedModule) => [
-  [%stri [@ocaml.warning "-32"]],
+  [%stri [@ocaml.warning "-32-34-60"]],
   [%stri include [%m moduleIdentFromGeneratedModule(["Utils"])]],
   [%stri module Types = [%m moduleIdentFromGeneratedModule(["Types"])]],
 ];

--- a/packages/rescript-relay/rescript-relay-ppx/library/Mutation.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Mutation.re
@@ -11,7 +11,7 @@ let make = (~loc, ~moduleName) => {
 
   Ast_helper.Mod.mk(
     Pmod_structure([
-      [%stri [@ocaml.warning "-32"]],
+      [%stri [@ocaml.warning "-32-34-60"]],
       [%stri include [%m moduleIdentFromGeneratedModule(["Utils"])]],
       [%stri module Types = [%m moduleIdentFromGeneratedModule(["Types"])]],
       [%stri

--- a/packages/rescript-relay/rescript-relay-ppx/library/Query.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Query.re
@@ -11,7 +11,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
 
   Ast_helper.Mod.mk(
     Pmod_structure([
-      [%stri [@ocaml.warning "-32"]],
+      [%stri [@ocaml.warning "-32-34-60"]],
       [%stri include [%m moduleIdentFromGeneratedModule(["Utils"])]],
       [%stri module Types = [%m moduleIdentFromGeneratedModule(["Types"])]],
       [%stri

--- a/packages/rescript-relay/rescript-relay-ppx/library/Subscription.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Subscription.re
@@ -11,7 +11,7 @@ let make = (~loc, ~moduleName) => {
 
   Ast_helper.Mod.mk(
     Pmod_structure([
-      [%stri [@ocaml.warning "-32"]],
+      [%stri [@ocaml.warning "-32-34-60"]],
       [%stri include [%m moduleIdentFromGeneratedModule(["Utils"])]],
       [%stri module Types = [%m moduleIdentFromGeneratedModule(["Types"])]],
       [%stri


### PR DESCRIPTION
This would happen when writing an interface file for a module using RescriptRelay.

For testing I enabled warnings as errors and added interface files for `Test_mutation.res` and `Test_subscription.res` that would fail with warning 60 before.

I checked and you don't actually need to reenable the disabled warnings afterwards, they would still be raised in the file where the PPX is used.