### PR TITLE
Run reanalyze with spawn

### DIFF
--- a/packages/rescript-relay-cli/index.ts
+++ b/packages/rescript-relay-cli/index.ts
@@ -200,7 +200,7 @@ program
     }) => {
       const spinner = ora("Analyzing ReScript project").start();
 
-      const p = cp.exec(`npx reanalyze -dce`);
+      const p = cp.spawn("npx", ["reanalyze", "-dce"]);
 
       if (p.stdout == null) {
         console.error("Something went wrong.");


### PR DESCRIPTION
Use child process spawn over exec to avoid running the buffer dry.
This should fix the problem with unused fields not being picked up.