### PR TITLE
Make it possible to have the relay config in package.json

### DIFF
--- a/packages/rescript-relay-cli/fileUtils.ts
+++ b/packages/rescript-relay-cli/fileUtils.ts
@@ -6,23 +6,6 @@ import config from "relay-config";
 import { Config } from "relay-compiler/lib/bin/RelayCompilerMain";
 
 export const loadRelayConfig = () => {
-  let exists = null;
-
-  try {
-    exists = fs.statSync(
-      path.resolve(path.join(process.cwd(), "relay.config.js")),
-      { throwIfNoEntry: false }
-    );
-  } catch {}
-
-  if (exists == null) {
-    console.error(
-      "relay.config.js must exist in the current working directory this script runs in."
-    );
-
-    process.exit(1);
-  }
-
   const relayConfig = config.loadConfig();
 
   if (!relayConfig) {


### PR DESCRIPTION
This PR lifts the requirement that the relay config must be defined in `relay.config.js`. Relay will try to load it from `relay.config.js` or `package.json`. So there shouldn't be a need for a hard requirement of having it in `relay.config.js`