### PR TITLE
Support setting a requiredFieldLogger

### DIFF
--- a/packages/rescript-relay/__tests__/Test_requiredFieldLogger-tests.js
+++ b/packages/rescript-relay/__tests__/Test_requiredFieldLogger-tests.js
@@ -1,24 +1,27 @@
 require("@testing-library/jest-dom/extend-expect");
 const queryMock = require("./queryMock");
 
-const { test_requiredFieldLogger, getLoggedValue, expectedValue } = require("./Test_requiredFieldLogger.bs");
+const {
+  test_requiredFieldLogger,
+  getLoggedValue,
+  expectedValue,
+} = require("./Test_requiredFieldLogger.bs");
 
 describe("RequiredFieldLogger", () => {
-    test("logs missing field", async () => {
-      queryMock.mockQuery({
-        name: "TestRequiredFieldLoggerQuery",
-        data: {
-          loggedInUser: {
-            id: "user-123",
-            firstName: null,
-          },
-          users: null,
+  test("logs missing field", async () => {
+    queryMock.mockQuery({
+      name: "TestRequiredFieldLoggerQuery",
+      data: {
+        loggedInUser: {
+          id: "user-123",
+          firstName: null,
         },
-      });
-
-      await test_requiredFieldLogger()
-
-      expect(getLoggedValue()).toBe(expectedValue)
-
+        users: null,
+      },
     });
+
+    await test_requiredFieldLogger();
+
+    expect(getLoggedValue()).toBe(expectedValue);
   });
+});

--- a/packages/rescript-relay/__tests__/Test_requiredFieldLogger-tests.js
+++ b/packages/rescript-relay/__tests__/Test_requiredFieldLogger-tests.js
@@ -1,0 +1,24 @@
+require("@testing-library/jest-dom/extend-expect");
+const queryMock = require("./queryMock");
+
+const { test_requiredFieldLogger, getLoggedValue, expectedValue } = require("./Test_requiredFieldLogger.bs");
+
+describe("RequiredFieldLogger", () => {
+    test("logs missing field", async () => {
+      queryMock.mockQuery({
+        name: "TestRequiredFieldLoggerQuery",
+        data: {
+          loggedInUser: {
+            id: "user-123",
+            firstName: null,
+          },
+          users: null,
+        },
+      });
+
+      await test_requiredFieldLogger()
+
+      expect(getLoggedValue()).toBe(expectedValue)
+
+    });
+  });

--- a/packages/rescript-relay/__tests__/Test_requiredFieldLogger.res
+++ b/packages/rescript-relay/__tests__/Test_requiredFieldLogger.res
@@ -1,9 +1,9 @@
 module Query = %relay(`
-    query TestRequiredFieldLoggerQuery {
-      loggedInUser {
-        firstName @required(action: LOG)
-      }
+  query TestRequiredFieldLoggerQuery {
+    loggedInUser {
+      firstName @required(action: LOG)
     }
+  }
 `)
 
 module Logger = {

--- a/packages/rescript-relay/__tests__/Test_requiredFieldLogger.res
+++ b/packages/rescript-relay/__tests__/Test_requiredFieldLogger.res
@@ -1,0 +1,43 @@
+module Query = %relay(`
+    query TestRequiredFieldLoggerQuery {
+      loggedInUser {
+        firstName @required(action: LOG)
+      }
+    }
+`)
+
+module Logger = {
+  let loggedValue = ref((None: option<string>))
+
+  let log = (~kind, ~owner, ~fieldPath) => {
+    loggedValue := Some(`kind: ${kind->Obj.magic}, owner: ${owner}, filedPath:${fieldPath}`)
+  }
+
+  let getLoggedValue = () => loggedValue.contents
+
+  let expectedValue = "kind: missing_field.log, owner: TestRequiredFieldLoggerQuery, filedPath:loggedInUser.firstName"
+}
+
+@live
+let test_requiredFieldLogger = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery, ())
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make(), ()),
+    ~requiredFieldLogger={
+      Logger.log
+    },
+    (),
+  )
+
+  RescriptRelay.relayFeatureFlags.enableRequiredDirective = true
+
+  Js.Promise.make((~resolve, ~reject as _) => {
+    Query.fetch(~environment, ~variables=(), ~onResult={res => resolve(. res)}, ())
+  })
+}
+
+let getLoggedValue = Logger.getLoggedValue
+
+let expectedValue = Logger.expectedValue

--- a/packages/rescript-relay/__tests__/__generated__/TestRequiredFieldLoggerQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRequiredFieldLoggerQuery_graphql.res
@@ -1,0 +1,161 @@
+/* @sourceLoc Test_requiredFieldLogger.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@ocaml.warning("-30")
+
+  type rec response_loggedInUser = {
+    firstName: string,
+  }
+  type response = {
+    loggedInUser: option<response_loggedInUser>,
+  }
+  type rawResponse = response
+  type variables = unit
+  type refetchVariables = unit
+  @live let makeRefetchVariables = () => ()
+}
+
+module Internal = {
+  @live
+  let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    Js.undefined
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    Js.null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    Js.undefined
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+
+type queryRef
+
+module Utils = {
+  @@ocaml.warning("-33")
+  open Types
+  @live let makeVariables = () => ()
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "firstName",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestRequiredFieldLoggerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "RequiredField",
+            "field": (v0/*: any*/),
+            "action": "LOG",
+            "path": "loggedInUser.firstName"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestRequiredFieldLoggerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2c336e01aca4db2f2e69aeb496c7ea4f",
+    "id": null,
+    "metadata": {},
+    "name": "TestRequiredFieldLoggerQuery",
+    "operationKind": "query",
+    "text": "query TestRequiredFieldLoggerQuery {\n  loggedInUser {\n    firstName\n    id\n  }\n}\n"
+  }
+};
+})() `)
+
+include RescriptRelay.MakeLoadQuery({
+    type variables = Types.variables
+    type loadedQueryRef = queryRef
+    type response = Types.response
+    type node = relayOperationNode
+    let query = node
+    let convertVariables = Internal.convertVariables
+});

--- a/packages/rescript-relay/src/RescriptRelay.resi
+++ b/packages/rescript-relay/src/RescriptRelay.resi
@@ -757,6 +757,18 @@ module Disposable: {
 }
 
 @ocaml.doc(
+  "A required field logger, which gets called when a field annotated with the @required directive was missing from the response"
+)
+module RequiredFieldLogger: {
+  type kind = [#"missing_field.log" | #"missing_field.throw"]
+
+  @ocaml.doc(
+    "A required field logger, which gets called when a field annotated with the @required directive was missing from the response"
+  )
+  type t = (~kind: kind, ~owner: string, ~fieldPath: string) => unit
+}
+
+@ocaml.doc(
   "Module representing the environment, which you'll need to use and pass to various functions. Takes a few configuration options like store and network layer."
 )
 module Environment: {
@@ -773,6 +785,7 @@ module Environment: {
     ) => string=?,
     ~treatMissingFieldsAsNull: bool=?,
     ~missingFieldHandlers: array<MissingFieldHandler.t>=?,
+    ~requiredFieldLogger: RequiredFieldLogger.t=?,
     unit,
   ) => t
 


### PR DESCRIPTION
👋  Let me know whether this binding looks good to you. I wanted to make it very close to the original JS one, except that the function accepts labeled arguments instead of a single argument which is an object.

The `kind` type might be awkward to interact with since it's a polymorphic variants with dots, so perhaps you'd rather have something more idiomatic even though it would diverge from the JS type. 

I added a test that pretty much covers the basic functionality, but let me know whether we should also test it with the `THROW` action.