### PR TITLE
Import hooks from main `react-relay` file

### DIFF
--- a/packages/rescript-relay/package.json
+++ b/packages/rescript-relay/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@rescript/react": "*",
-    "react-relay": "*",
+    "react-relay": "=>11.0.0",
     "relay-runtime": "*",
     "rescript": "^9.1.2"
   },

--- a/packages/rescript-relay/rescript-relay-ppx/library/FragmentUtils.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/FragmentUtils.re
@@ -22,7 +22,7 @@ let makeInternalExternals = (~loc, ~typeFromGeneratedModule) => [
   ],
   [%stri
     %private
-    [@live] [@module "react-relay/hooks"]
+    [@live] [@module "react-relay"]
     external internal_useFragment:
       (
         RescriptRelay.fragmentNode(
@@ -35,7 +35,7 @@ let makeInternalExternals = (~loc, ~typeFromGeneratedModule) => [
   ],
   [%stri
     %private
-    [@live] [@module "react-relay/hooks"]
+    [@live] [@module "react-relay"]
     external internal_useFragmentOpt:
       (
         RescriptRelay.fragmentNode(
@@ -171,7 +171,7 @@ let makeRefetchableAssets =
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_usePaginationFragment:
           (
             RescriptRelay.fragmentNode(
@@ -184,7 +184,7 @@ let makeRefetchableAssets =
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_useBlockingPaginationFragment:
           (
             RescriptRelay.fragmentNode(
@@ -197,7 +197,7 @@ let makeRefetchableAssets =
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_useRefetchableFragment:
           (
             RescriptRelay.fragmentNode(

--- a/packages/rescript-relay/rescript-relay-ppx/library/Mutation.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Mutation.re
@@ -100,7 +100,7 @@ let make = (~loc, ~moduleName) => {
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_useMutation:
           RescriptRelay.mutationNode(
             [%t typeFromGeneratedModule(["relayOperationNode"])],

--- a/packages/rescript-relay/rescript-relay-ppx/library/Query.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Query.re
@@ -37,7 +37,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_useQuery:
           (
             RescriptRelay.queryNode(
@@ -51,7 +51,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_usePreloadedQuery:
           (
             RescriptRelay.queryNode(
@@ -70,7 +70,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_useQueryLoader:
           RescriptRelay.queryNode(
             [%t typeFromGeneratedModule(["relayOperationNode"])],
@@ -88,7 +88,7 @@ let make = (~loc, ~moduleName, ~hasRawResponseType) => {
       ],
       [%stri
         %private
-        [@module "react-relay/hooks"] [@live]
+        [@module "react-relay"] [@live]
         external internal_fetchQuery:
           (
             RescriptRelay.Environment.t,

--- a/packages/rescript-relay/src/RescriptRelay.res
+++ b/packages/rescript-relay/src/RescriptRelay.res
@@ -703,7 +703,7 @@ type loadQueryConfig = {
   networkCacheConfig: option<cacheConfig>,
 }
 
-@module("react-relay/hooks")
+@module("react-relay")
 external loadQuery: (Environment.t, queryNode<'a>, 'variables, loadQueryConfig) => 'queryResponse =
   "loadQuery"
 
@@ -775,6 +775,6 @@ external commitLocalUpdate: (
   ~updater: RecordSourceSelectorProxy.t => unit,
 ) => unit = "commitLocalUpdate"
 
-@module("react-relay/hooks")
+@module("react-relay")
 external useSubscribeToInvalidationState: (array<dataId>, unit => unit) => Disposable.t =
   "useSubscribeToInvalidationState"

--- a/packages/rescript-relay/src/RescriptRelay.resi
+++ b/packages/rescript-relay/src/RescriptRelay.resi
@@ -891,7 +891,7 @@ external commitLocalUpdate: (
 @ocaml.doc(
   "Allows you to subscribe to when a record, connection, or even the store itself is invalidated, and then react to that."
 )
-@module("react-relay/hooks")
+@module("react-relay")
 external useSubscribeToInvalidationState: (array<dataId>, unit => unit) => Disposable.t =
   "useSubscribeToInvalidationState"
 


### PR DESCRIPTION
All hook imports are available from `react-relay/index.js` (specified in
`main` in the `package.json`) as of react-relay 11.0.0.

Bundlers have no issues in resolving `react-relay/hooks` to
`react-relay/hooks.js` but NodeJs `require` or `import` calls are more
strict, which means that `import * as Hooks from "react-relay/hooks"`
fails in a NodeJs environment.

By importing from the package's primary entry point we ensure that
Node's file resolver is also happy.

The peer dependency is bumped to require at least react-relay 11.0.0
which introduced the change. `=>` is used because it keeps the
open-ended upper bound that `*` also had.

The react-relay commit that makes the changes (and the tags it's in) 
can be found here: https://github.com/facebook/relay/commit/2d253c073fab38072c6e1db0c723484bec2bb9e4