### PR TITLE
Remove ocaml-migrate-parsetree

### DIFF
--- a/packages/rescript-relay/rescript-relay-ppx/bin/RescriptRelayPpxApp.re
+++ b/packages/rescript-relay/rescript-relay-ppx/bin/RescriptRelayPpxApp.re
@@ -1,4 +1,4 @@
-open Migrate_parsetree;
+open Ppxlib;
 open RescriptRelayPpxLibrary;
 
 Driver.run_as_ppx_rewriter();

--- a/packages/rescript-relay/rescript-relay-ppx/bin/RescriptRelayPpxApp.re
+++ b/packages/rescript-relay/rescript-relay-ppx/bin/RescriptRelayPpxApp.re
@@ -1,4 +1,3 @@
 open Ppxlib;
-open RescriptRelayPpxLibrary;
 
 Driver.run_as_ppx_rewriter();

--- a/packages/rescript-relay/rescript-relay-ppx/bin/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/bin/dune
@@ -1,13 +1,4 @@
-(executable (name RescriptRelayPpxApp)
-    (modules (:standard \ RescriptRelayPpxBinPesyModules))
-    (public_name RescriptRelayPpxApp.exe)
-    (libraries rescript-relay-ppx.bin.pesy-modules)
-    (flags -open RescriptRelayPpxBinPesyModules))
-(library (public_name rescript-relay-ppx.bin.pesy-modules)
-    (name RescriptRelayPpxBinPesyModules)
-    (modules RescriptRelayPpxBinPesyModules)
-    (libraries rescript-relay-ppx.library ppxlib graphql_parser str)
-    (preprocess (pps ppxlib.metaquot)))
-(rule
-    (with-stdout-to RescriptRelayPpxBinPesyModules.re
-        (run echo "module Library = RescriptRelayPpxLibrary;")))
+(executable
+ (name RescriptRelayPpxApp)
+ (public_name RescriptRelayPpxApp.exe)
+ (libraries ppxlib))

--- a/packages/rescript-relay/rescript-relay-ppx/bin/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/bin/dune
@@ -6,7 +6,7 @@
 (library (public_name rescript-relay-ppx.bin.pesy-modules)
     (name RescriptRelayPpxBinPesyModules)
     (modules RescriptRelayPpxBinPesyModules)
-    (libraries rescript-relay-ppx.library ocaml-migrate-parsetree ppxlib graphql_parser str)
+    (libraries rescript-relay-ppx.library ppxlib graphql_parser str)
     (preprocess (pps ppxlib.metaquot)))
 (rule
     (with-stdout-to RescriptRelayPpxBinPesyModules.re

--- a/packages/rescript-relay/rescript-relay-ppx/library/Util.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Util.re
@@ -149,7 +149,7 @@ let rec selectionSetHasConnection = selections =>
   | None => false
   };
 
-let rec extractFieldWithConnectionDirective =
+let extractFieldWithConnectionDirective =
         (selections): option(Graphql_parser.field) =>
   switch (
     selections

--- a/packages/rescript-relay/rescript-relay-ppx/library/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/library/dune
@@ -1,5 +1,8 @@
-(library (name RescriptRelayPpxLibrary) (public_name rescript-relay-ppx.library)
-    (libraries  ppxlib graphql_parser str)
-    (kind ppx_rewriter)
-    (preprocess (pps ppxlib.metaquot))
-    (flags :standard -w -9-27))
+(library
+ (name RescriptRelayPpxLibrary)
+ (public_name rescript-relay-ppx)
+ (libraries ppxlib graphql_parser str)
+ (kind ppx_rewriter)
+ (preprocess
+  (pps ppxlib.metaquot))
+ (flags :standard -w -9-27))

--- a/packages/rescript-relay/rescript-relay-ppx/library/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/library/dune
@@ -1,15 +1,5 @@
 (library (name RescriptRelayPpxLibrary) (public_name rescript-relay-ppx.library)
-    (modules (:standard \ RescriptRelayPpxLibraryPesyModules))
-    (libraries rescript-relay-ppx.library.pesy-modules)
-    (flags -open RescriptRelayPpxLibraryPesyModules)
+    (libraries  ppxlib graphql_parser str)
     (kind ppx_rewriter)
-    (preprocess (pps ppxlib.metaquot)))
-(library (public_name rescript-relay-ppx.library.pesy-modules)
-    (name RescriptRelayPpxLibraryPesyModules)
-    (modules RescriptRelayPpxLibraryPesyModules)
-    (libraries console.lib pastel.lib ocaml-migrate-parsetree ppxlib graphql_parser str)
-    (preprocess (pps ppxlib.metaquot)))
-(rule
-    (with-stdout-to RescriptRelayPpxLibraryPesyModules.re
-        (run echo  "module Console = Console;\
-                  \nmodule Pastel = Pastel;")))
+    (preprocess (pps ppxlib.metaquot))
+    (flags :standard -w -9-27))

--- a/packages/rescript-relay/rescript-relay-ppx/package.json
+++ b/packages/rescript-relay/rescript-relay-ppx/package.json
@@ -61,8 +61,6 @@
     "@esy-ocaml/reason": "*",
     "@opam/dune": "*",
     "@opam/graphql_parser": "0.12.2",
-    "@opam/ocaml-migrate-parsetree": "1.4.0",
-    "@opam/ppx_tools_versioned": "5.2.3",
     "@opam/ppxlib": "*",
     "@reason-native/rely": "*",
     "ocaml": "4.6.1002",

--- a/packages/rescript-relay/rescript-relay-ppx/package.json
+++ b/packages/rescript-relay/rescript-relay-ppx/package.json
@@ -14,42 +14,6 @@
       "ODOC_SYNTAX": "re"
     }
   },
-  "buildDirs": {
-    "test": {
-      "imports": [
-        "Library = require('rescript-relay-ppx/library')",
-        "Rely = require('rely/lib')"
-      ],
-      "flags": [
-        "-linkall",
-        "-g",
-        "-w",
-        "-9"
-      ]
-    },
-    "testExe": {
-      "imports": [
-        "Test = require('rescript-relay-ppx/test')"
-      ],
-      "bin": {
-        "RunRescriptRelayPpxTests.exe": "RunRescriptRelayPpxTests.re"
-      }
-    },
-    "library": {
-      "imports": [
-        "Console = require('console/lib')",
-        "Pastel = require('pastel/lib')"
-      ]
-    },
-    "bin": {
-      "imports": [
-        "Library = require('rescript-relay-ppx/library')"
-      ],
-      "bin": {
-        "RescriptRelayPpxApp.exe": "RescriptRelayPpxApp.re"
-      }
-    }
-  },
   "scripts": {
     "start": "esy x RescriptRelayPpxApp.exe",
     "test": "esy x RunRescriptRelayPpxTests.exe",

--- a/packages/rescript-relay/rescript-relay-ppx/test/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/test/dune
@@ -1,18 +1,4 @@
 (library
  (name RescriptRelayPpxTest)
- (public_name rescript-relay-ppx.test)
- (modules
-  (:standard \ RescriptRelayPpxTestPesyModules))
- (libraries rescript-relay-ppx.test.pesy-modules)
- (flags -linkall -g -w -9 -open RescriptRelayPpxTestPesyModules))
-
-(library
- (public_name rescript-relay-ppx.test.pesy-modules)
- (name RescriptRelayPpxTestPesyModules)
- (modules RescriptRelayPpxTestPesyModules)
- (libraries rescript-relay-ppx.library rely.lib))
-
-(rule
- (with-stdout-to
-  RescriptRelayPpxTestPesyModules.re
-  (run echo "module Library = RescriptRelayPpxLibrary;\nmodule Rely = Rely;")))
+ (libraries rely.lib rescript-relay-ppx)
+ (flags -linkall -g -w -9))

--- a/packages/rescript-relay/rescript-relay-ppx/testExe/RunRescriptRelayPpxTests.re
+++ b/packages/rescript-relay/rescript-relay-ppx/testExe/RunRescriptRelayPpxTests.re
@@ -1,1 +1,1 @@
-Test.TestFramework.cli();
+RescriptRelayPpxTest.TestFramework.cli();

--- a/packages/rescript-relay/rescript-relay-ppx/testExe/dune
+++ b/packages/rescript-relay/rescript-relay-ppx/testExe/dune
@@ -1,12 +1,3 @@
-(executable (name RunRescriptRelayPpxTests)
-    (modules (:standard \ RescriptRelayPpxTestExePesyModules))
-    (public_name RunRescriptRelayPpxTests.exe)
-    (libraries rescript-relay-ppx.testExe.pesy-modules)
-    (flags -open RescriptRelayPpxTestExePesyModules))
-(library (public_name rescript-relay-ppx.testExe.pesy-modules)
-    (name RescriptRelayPpxTestExePesyModules)
-    (modules RescriptRelayPpxTestExePesyModules)
-    (libraries rescript-relay-ppx.test))
-(rule
-    (with-stdout-to RescriptRelayPpxTestExePesyModules.re
-        (run echo "module Test = RescriptRelayPpxTest;")))
+(executable
+ (name RunRescriptRelayPpxTests)
+ (libraries RescriptRelayPpxTest))


### PR DESCRIPTION
I couldn't actually get esy to run after removing these dependencies so the lockfiles might need to be updated

This should allow rescript-relay to work with melange.