### PR TITLE
Fix incorrect `react-relay` peerDependencies version

### DIFF
--- a/packages/rescript-relay/package.json
+++ b/packages/rescript-relay/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "@rescript/react": "*",
-    "react-relay": "=>11.0.0",
+    "react-relay": ">=11.0.0",
     "relay-runtime": "*",
     "rescript": "^9.1.2"
   },


### PR DESCRIPTION
Closes #355

Can't be tested until it's on npm but should be good I think. That is something I am using in various places in rescript-react-native packages.