### PR TITLE
Add undocumented holdGC  method on relay store

### DIFF
--- a/packages/rescript-relay/src/RescriptRelay.res
+++ b/packages/rescript-relay/src/RescriptRelay.res
@@ -572,6 +572,7 @@ module Store = {
 
   @send external getSource: t => RecordSource.t = "getSource"
   @send external publish: (t, RecordSource.t) => unit = "publish"
+  @send external holdGC: t => unit = "holdGC"
 }
 
 module RequiredFieldLogger = {

--- a/packages/rescript-relay/src/RescriptRelay.resi
+++ b/packages/rescript-relay/src/RescriptRelay.resi
@@ -765,6 +765,12 @@ module Store: {
   )
   @send
   external publish: (t, RecordSource.t) => unit = "publish"
+
+  @ocaml.doc(
+    "Informes the store to stop its normal garbage collection processes. This prevents data being lost between calling relay's `fetchQuery` any serialization process (eg: toJSON)"
+  )
+  @send
+  external holdGC: t => unit = "holdGC"
 }
 
 @ocaml.doc("Internal, do not use.")


### PR DESCRIPTION
https://github.com/facebook/relay/blob/b6c6b7d28a0121f97ad20d17c716c3b905ee6c82/packages/relay-runtime/store/RelayModernStore.js#L429

Found it's usage here https://github.com/vercel/next.js/pull/33892/files#diff-785b30f413e5f6cb7213e3c49e073fd5758dca3315febd2f12630f35fca7ecf3R49