### PR TITLE
fix: Protect with try ~ catch on postinstall.

### DIFF
--- a/packages/rescript-relay/scripts/release-postinstall.js
+++ b/packages/rescript-relay/scripts/release-postinstall.js
@@ -94,49 +94,55 @@ function ppxArch() {
 }
 
 function copyPlatformBinaries(platform) {
-  /**
-   * Copy the PPX
-   */
-  fs.copyFileSync(
-    path.join(__dirname, "ppx-" + platform),
-    path.join(__dirname, "ppx")
-  );
-  fs.chmodSync(path.join(__dirname, "ppx"), 0777);
+  try {
+    /**
+       * Copy the PPX
+       */
+    fs.copyFileSync(
+      path.join(__dirname, "ppx-" + platform),
+      path.join(__dirname, "ppx")
+    );
+    fs.chmodSync(path.join(__dirname, "ppx"), 0777);
 
-  /**
-   * Copy the Relay compiler
-   */
+    /**
+     * Copy the Relay compiler
+     */
 
-  fs.copyFileSync(
-    path.join(
-      __dirname,
-      "relay-compiler-" + getRelayCompilerPlatformSuffix(),
-      "relay"
-    ),
-    path.join(__dirname, "rescript-relay-compiler.exe")
-  );
-  fs.chmodSync(path.join(__dirname, "rescript-relay-compiler.exe"), 0777);
+    fs.copyFileSync(
+      path.join(
+        __dirname,
+        "relay-compiler-" + getRelayCompilerPlatformSuffix(),
+        "relay"
+      ),
+      path.join(__dirname, "rescript-relay-compiler.exe")
+    );
+    fs.chmodSync(path.join(__dirname, "rescript-relay-compiler.exe"), 0777);
+  } catch (err) {}
+  
 }
 
 function removeInitialBinaries() {
-  fs.unlinkSync(path.join(__dirname, "ppx-darwin"));
-  fs.unlinkSync(path.join(__dirname, "ppx-linux"));
-  fs.rmSync(path.join(__dirname, "relay-compiler-linux-x64"), {
-    recursive: true,
-    force: true,
-  });
-  fs.rmSync(path.join(__dirname, "relay-compiler-macos-x64"), {
-    recursive: true,
-    force: true,
-  });
-  fs.rmSync(path.join(__dirname, "relay-compiler-macos-arm64"), {
-    recursive: true,
-    force: true,
-  });
-  fs.rmSync(path.join(__dirname, "relay-compiler-linux-musl"), {
-    recursive: true,
-    force: true,
-  });
+  try {
+    fs.unlinkSync(path.join(__dirname, "ppx-darwin"));
+    fs.unlinkSync(path.join(__dirname, "ppx-linux"));
+    fs.rmSync(path.join(__dirname, "relay-compiler-linux-x64"), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(__dirname, "relay-compiler-macos-x64"), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(__dirname, "relay-compiler-macos-arm64"), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(__dirname, "relay-compiler-linux-musl"), {
+      recursive: true,
+      force: true,
+    });
+  } catch (err) {}
+  
 }
 
 switch (platform) {


### PR DESCRIPTION
Postinstall error when using yarn workspace. A patch that protects this case.

https://github.com/yarnpkg/yarn/issues/7694


```
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 252ms
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 613ms
➤ YN0000: ┌ Link step
➤ YN0007: │ rescript-relay@npm:1.0.0-beta.20 [99da6] must be built because it never has been before or the last one failed
➤ YN0009: │ rescript-relay@npm:1.0.0-beta.20 [99da6] couldn't be built successfully (exit code 1, logs can be found here: /private/var/folders/_9/4r7lk75947nd53l3751p8ltw0000gn/T/xfs-0f7f7f6d/build.log)
```


### build.log
```
# This file contains the result of Yarn building a package (rescript-relay@virtual:99da68c324550f8710c415b829bbd9a394bff34ad8514f31346cdabf0527966a11332d6b07f65324969b2168a9318e26017d916aa168344f5c553310763e3dc8#npm:1.0.0-beta.20)
# Script name: postinstall

Error: ENOENT: no such file or directory, copyfile '/some/node_modules/rescript-relay/ppx-darwin' -> '/some/node_modules/rescript-relay/ppx'
    at Object.copyFileSync (node:fs:2800:3)
    at copyPlatformBinaries (/some/node_modules/rescript-relay/postinstall.js:101:7)
    at Object.<anonymous> (/some/node_modules/rescript-relay/postinstall.js:158:5)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'copyfile',
  code: 'ENOENT',
  path: '/some/node_modules/rescript-relay/ppx-darwin',
  dest: '/some/node_modules/rescript-relay/ppx'
}
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOENT: no such file or directory, unlink '/some/node_modules/rescript-relay/ppx-darwin'
    at Object.unlinkSync (node:fs:1718:3)
    at removeInitialBinaries (/some/node_modules/rescript-relay/postinstall.js:127:6)
    at Object.<anonymous> (/some/node_modules/rescript-relay/postinstall.js:165:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  errno: -2,
  syscall: 'unlink',
  code: 'ENOENT',
  path: '/some/node_modules/rescript-relay/ppx-darwin'
}
```