### PR TITLE
Connection ID makers + shared type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ You can go ahead and remove these packages, that are no longer needed, as the co
 
 ### unreleased
 
+- A `RelaySchemaAssets_graphql.res` is now emitted, containing type definitions for all enums and all input objects. This is designed to help with accessing and using enums and input objects outside of Relay's context. This means it'll be much easier to share makers for input objects, pass enums around, etc.
+- Each fragment with a `@connection` now emits a `makeConnectionId` function that allows you to generate _type safe_ connection IDs. More on why this is useful in the documentation.
+
 ## beta.26
 
 - Upgrade Relay packages to version `14.1.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ You can go ahead and remove these packages, that are no longer needed, as the co
 
 - A `RelaySchemaAssets_graphql.res` is now emitted, containing type definitions for all enums and all input objects. This is designed to help with accessing and using enums and input objects outside of Relay's context. This means it'll be much easier to share makers for input objects, pass enums around, etc.
 - Each fragment with a `@connection` now emits a `makeConnectionId` function that allows you to generate _type safe_ connection IDs. More on why this is useful in the documentation.
+- _breaking_ Input object fields with illegal names in ReScript previously had their maker function argument names suffixed with `_`, like `~type_: string`. This is now instead _prefixed_, like `~_type: string`. Prefixing like this instead of suffixing means we can ship fully zero cost maker functions, which we couldn't before for input objects with illegal field names.
 
 ## beta.26
 

--- a/packages/rescript-relay/__tests__/Test_connections-tests.js
+++ b/packages/rescript-relay/__tests__/Test_connections-tests.js
@@ -1,0 +1,57 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+const ReactTestUtils = require("react-dom/test-utils");
+
+const { test_connections } = require("./Test_connections.bs");
+
+describe("Connections", () => {
+  test("basic fragments work", async () => {
+    queryMock.mockQuery({
+      name: "TestConnectionsQuery",
+      variables: {
+        beforeDate: "2022-01-01T00:00:00.000Z",
+      },
+      data: {
+        loggedInUser: {
+          __typename: "User",
+          id: "user-1",
+          friendsConnection: {
+            pageInfo: {
+              endCursor: null,
+              startCursor: null,
+              hasNextPage: false,
+              hasPreviousPage: false,
+            },
+            edges: [
+              { cursor: "user-2", node: { id: "user-2", __typename: "User" } },
+            ],
+          },
+        },
+      },
+    });
+
+    t.render(test_connections());
+    await t.screen.findByText("user-2");
+
+    queryMock.mockQuery({
+      name: "TestConnections_AddFriendMutation",
+      matchVariables: (v) => true,
+      data: {
+        addFriend: {
+          addedFriend: {
+            __typename: "User",
+            id: "user-3",
+          },
+        },
+      },
+    });
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Add friend"));
+    });
+
+    await t.screen.findByText("user-3");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_connections-tests.js
+++ b/packages/rescript-relay/__tests__/Test_connections-tests.js
@@ -10,9 +10,7 @@ describe("Connections", () => {
   test("basic fragments work", async () => {
     queryMock.mockQuery({
       name: "TestConnectionsQuery",
-      variables: {
-        beforeDate: "2022-01-01T00:00:00.000Z",
-      },
+      matchVariables: (_) => true,
       data: {
         loggedInUser: {
           __typename: "User",
@@ -37,7 +35,7 @@ describe("Connections", () => {
 
     queryMock.mockQuery({
       name: "TestConnections_AddFriendMutation",
-      matchVariables: (v) => true,
+      matchVariables: (_) => true,
       data: {
         addFriend: {
           addedFriend: {

--- a/packages/rescript-relay/__tests__/Test_connections.res
+++ b/packages/rescript-relay/__tests__/Test_connections.res
@@ -1,0 +1,102 @@
+module Fragment = %relay(`
+  fragment TestConnections_user on User
+    @argumentDefinitions(
+      onlineStatuses: { type: "[OnlineStatus!]", defaultValue: [Idle] }
+      count: { type: "Int", defaultValue: 2 }
+      cursor: { type: "String", defaultValue: "" }
+      beforeDate: { type: "Datetime!" }
+    ) {
+    __id
+    friendsConnection(
+      statuses: $onlineStatuses
+      first: $count
+      after: $cursor
+      beforeDate: $beforeDate
+    ) @connection(key: "TestConnections_user_friendsConnection") {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`)
+
+module Query = %relay(`
+  query TestConnectionsQuery($beforeDate: Datetime!) {
+      loggedInUser {
+        ...TestConnections_user @arguments(beforeDate: $beforeDate)
+      }
+    }
+`)
+
+module AddFriendMutation = %relay(`
+    mutation TestConnections_AddFriendMutation($friendId: ID!, $connections: [ID!]!) {
+      addFriend(friendId: $friendId) {
+        addedFriend @appendNode(edgeTypeName: "UserEdge", connections: $connections) {
+          id
+        }
+      }
+    }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let makeDate = () =>
+      Js.Date.makeWithYMDHMS(
+        ~date=1.,
+        ~hours=1.,
+        ~minutes=0.,
+        ~month=0.,
+        ~seconds=0.,
+        ~year=2022.,
+        (),
+      )
+
+    let query = Query.use(
+      ~variables={
+        beforeDate: makeDate(),
+      },
+      (),
+    )
+    let user = Fragment.use(query.loggedInUser.fragmentRefs)
+    let friends = user.friendsConnection->Fragment.getConnectionNodes
+    let (addFriend, _isAddingFriend) = AddFriendMutation.use()
+
+    <div>
+      {friends
+      ->Belt.Array.map(friend => <div key=friend.id> {React.string(friend.id)} </div>)
+      ->React.array}
+      <button
+        onClick={_ => {
+          let _: RescriptRelay.Disposable.t = addFriend(
+            ~variables=AddFriendMutation.makeVariables(
+              ~connections={
+                open TestConnections_user_graphql.Utils
+                [user.__id->makeConnectionId(~beforeDate=makeDate(), ())]
+              },
+              ~friendId="123",
+            ),
+            (),
+          )
+        }}>
+        {React.string("Add friend")}
+      </button>
+    </div>
+  }
+}
+
+@live
+let test_connections = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery, ())
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make(), ()),
+    (),
+  )
+  ()
+
+  <TestProviders.Wrapper environment> <Test /> </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -30,7 +30,30 @@ type enum_RequiredFieldAction_input = [
 ]
 
 @live
-type rec input_RecursiveSetOnlineStatusInput = {
+type rec input_InputA = {
+  time: TestsUtils.Datetime.t,
+  recursiveA: option<input_InputA>,
+  usingB: option<input_InputB>,
+}
+
+@live
+and input_InputB = {
+  time: option<TestsUtils.Datetime.t>,
+  usingA: option<input_InputA>,
+  @as("constraint") constraint_: option<bool>,
+}
+
+@live
+and input_SomeInput = {
+  str: option<string>,
+  bool: option<bool>,
+  float: option<float>,
+  int: option<int>,
+  recursive: option<input_SomeInput>,
+}
+
+@live
+and input_RecursiveSetOnlineStatusInput = {
   someValue: TestsUtils.IntString.t,
   setOnlineStatus: option<input_SetOnlineStatusInput>,
 }
@@ -47,6 +70,40 @@ and input_SearchInput = {
   id: int,
   someOtherId: option<float>,
 }
+
+@live
+and input_PesticideListSearchInput = {
+  companyName: option<array<string>>,
+  pesticideIds: option<array<int>>,
+  skip: int,
+  take: int,
+}
+@live @obj
+external make_InputA: (
+  ~time: TestsUtils.Datetime.t,
+  ~recursiveA: input_InputA=?,
+  ~usingB: input_InputB=?,
+  unit,
+) => input_InputA = ""
+
+@live @obj
+external make_InputB: (
+  ~time: TestsUtils.Datetime.t=?,
+  ~usingA: input_InputA=?,
+  ~_constraint: bool=?,
+  unit,
+) => input_InputB = ""
+
+@live @obj
+external make_SomeInput: (
+  ~str: string=?,
+  ~bool: bool=?,
+  ~float: float=?,
+  ~int: int=?,
+  ~recursive: input_SomeInput=?,
+  unit,
+) => input_SomeInput = ""
+
 @live @obj
 external make_RecursiveSetOnlineStatusInput: (
   ~someValue: TestsUtils.IntString.t,
@@ -68,4 +125,13 @@ external make_SearchInput: (
   ~someOtherId: float=?,
   unit,
 ) => input_SearchInput = ""
+
+@live @obj
+external make_PesticideListSearchInput: (
+  ~companyName: array<string>=?,
+  ~pesticideIds: array<int>=?,
+  ~skip: int,
+  ~take: int,
+  unit,
+) => input_PesticideListSearchInput = ""
 

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -1,0 +1,71 @@
+/* @generated */
+@@ocaml.warning("-30")
+
+@live
+type enum_OnlineStatus = private [>
+  | #Online
+  | #Idle
+  | #Offline
+]
+
+@live
+type enum_OnlineStatus_input = [
+  | #Online
+  | #Idle
+  | #Offline
+]
+
+@live
+type enum_RequiredFieldAction = private [>
+  | #NONE
+  | #LOG
+  | #THROW
+]
+
+@live
+type enum_RequiredFieldAction_input = [
+  | #NONE
+  | #LOG
+  | #THROW
+]
+
+@live
+type rec input_RecursiveSetOnlineStatusInput = {
+  someValue: TestsUtils.IntString.t,
+  setOnlineStatus: option<input_SetOnlineStatusInput>,
+}
+
+@live
+and input_SetOnlineStatusInput = {
+  onlineStatus: [#Online | #Idle | #Offline],
+  recursed: option<input_RecursiveSetOnlineStatusInput>,
+}
+
+@live
+and input_SearchInput = {
+  names: option<array<option<string>>>,
+  id: int,
+  someOtherId: option<float>,
+}
+@live @obj
+external make_RecursiveSetOnlineStatusInput: (
+  ~someValue: TestsUtils.IntString.t,
+  ~setOnlineStatus: input_SetOnlineStatusInput=?,
+  unit,
+) => input_RecursiveSetOnlineStatusInput = ""
+
+@live @obj
+external make_SetOnlineStatusInput: (
+  ~onlineStatus: [#Online | #Idle | #Offline],
+  ~recursed: input_RecursiveSetOnlineStatusInput=?,
+  unit,
+) => input_SetOnlineStatusInput = ""
+
+@live @obj
+external make_SearchInput: (
+  ~names: array<option<string>>=?,
+  ~id: int,
+  ~someOtherId: float=?,
+  unit,
+) => input_SearchInput = ""
+

--- a/packages/rescript-relay/__tests__/__generated__/TestConnectionsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnectionsQuery_graphql.res
@@ -1,0 +1,303 @@
+/* @sourceLoc Test_connections.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@ocaml.warning("-30")
+
+  type rec response_loggedInUser = {
+    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestConnections_user]>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = {
+    beforeDate: TestsUtils.Datetime.t,
+  }
+  @live
+  type refetchVariables = {
+    beforeDate: option<TestsUtils.Datetime.t>,
+  }
+  @live let makeRefetchVariables = (
+    ~beforeDate=?,
+    ()
+  ): refetchVariables => {
+    beforeDate: beforeDate
+  }
+
+}
+
+module Internal = {
+  @live
+  let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{"__root":{"beforeDate":{"c":"TestsUtils.Datetime"}}}`
+  )
+  @live
+  let variablesConverterMap = {
+    "TestsUtils.Datetime": TestsUtils.Datetime.serialize,
+  }
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    Js.undefined
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{"__root":{"loggedInUser":{"f":""}}}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    Js.null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{"__root":{"loggedInUser":{"f":""}}}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    Js.undefined
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+
+type queryRef
+
+module Utils = {
+  @@ocaml.warning("-33")
+  open Types
+  @live @obj external makeVariables: (
+    ~beforeDate: TestsUtils.Datetime.t,
+  ) => variables = ""
+
+
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "beforeDate"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "beforeDate",
+  "variableName": "beforeDate"
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "after",
+    "value": ""
+  },
+  (v1/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 2
+  },
+  {
+    "kind": "Literal",
+    "name": "statuses",
+    "value": [
+      "Idle"
+    ]
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestConnectionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          {
+            "args": [
+              (v1/*: any*/)
+            ],
+            "kind": "FragmentSpread",
+            "name": "TestConnections_user"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TestConnectionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "UserConnection",
+            "kind": "LinkedField",
+            "name": "friendsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "UserEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "filters": [
+              "statuses",
+              "beforeDate"
+            ],
+            "handle": "connection",
+            "key": "TestConnections_user_friendsConnection",
+            "kind": "LinkedHandle",
+            "name": "friendsConnection"
+          },
+          {
+            "kind": "ClientExtension",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__id",
+                "storageKey": null
+              }
+            ]
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f85d0e2a4fdccf6cc34e34573d26baa1",
+    "id": null,
+    "metadata": {},
+    "name": "TestConnectionsQuery",
+    "operationKind": "query",
+    "text": "query TestConnectionsQuery(\n  $beforeDate: Datetime!\n) {\n  loggedInUser {\n    ...TestConnections_user_3xCS8w\n    id\n  }\n}\n\nfragment TestConnections_user_3xCS8w on User {\n  friendsConnection(statuses: [Idle], first: 2, after: \"\", beforeDate: $beforeDate) {\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+  }
+};
+})() `)
+
+include RescriptRelay.MakeLoadQuery({
+    type variables = Types.variables
+    type loadedQueryRef = queryRef
+    type response = Types.response
+    type node = relayOperationNode
+    let query = node
+    let convertVariables = Internal.convertVariables
+});

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections_AddFriendMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections_AddFriendMutation_graphql.res
@@ -1,0 +1,208 @@
+/* @sourceLoc Test_connections.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@ocaml.warning("-30")
+
+  @live
+  type rec response_addFriend_addedFriend = {
+    @live id: string,
+  }
+  @live
+  and response_addFriend = {
+    addedFriend: option<response_addFriend_addedFriend>,
+  }
+  @live
+  type response = {
+    addFriend: option<response_addFriend>,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = {
+    connections: array<RescriptRelay.dataId>,
+    friendId: string,
+  }
+}
+
+module Internal = {
+  @live
+  let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    Js.undefined
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    Js.null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    Js.undefined
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+module Utils = {
+  @@ocaml.warning("-33")
+  open Types
+  @live @obj external makeVariables: (
+    ~connections: array<RescriptRelay.dataId>,
+    ~friendId: string,
+  ) => variables = ""
+
+
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.mutationNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "connections"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "friendId"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "friendId",
+    "variableName": "friendId"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "addedFriend",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestConnections_AddFriendMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "AddFriendPayload",
+        "kind": "LinkedField",
+        "name": "addFriend",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
+    "kind": "Operation",
+    "name": "TestConnections_AddFriendMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "AddFriendPayload",
+        "kind": "LinkedField",
+        "name": "addFriend",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "appendNode",
+            "key": "",
+            "kind": "LinkedHandle",
+            "name": "addedFriend",
+            "handleArgs": [
+              {
+                "kind": "Variable",
+                "name": "connections",
+                "variableName": "connections"
+              },
+              {
+                "kind": "Literal",
+                "name": "edgeTypeName",
+                "value": "UserEdge"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "24b9201349e60cd6ca9e4e52bd034613",
+    "id": null,
+    "metadata": {},
+    "name": "TestConnections_AddFriendMutation",
+    "operationKind": "mutation",
+    "text": "mutation TestConnections_AddFriendMutation(\n  $friendId: ID!\n) {\n  addFriend(friendId: $friendId) {\n    addedFriend {\n      id\n    }\n  }\n}\n"
+  }
+};
+})() `)
+
+

--- a/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestConnections_user_graphql.res
@@ -1,4 +1,4 @@
-/* @sourceLoc Test_paginationInNode.res */
+/* @sourceLoc Test_connections.res */
 /* @generated */
 %%raw("/* @generated */")
 module Types = {
@@ -6,7 +6,6 @@ module Types = {
 
   type rec fragment_friendsConnection_edges_node = {
     @live id: string,
-    fragmentRefs: RescriptRelay.fragmentRefs<[ | #TestPaginationInNode_user]>,
   }
   and fragment_friendsConnection_edges = {
     node: option<fragment_friendsConnection_edges_node>,
@@ -15,8 +14,8 @@ module Types = {
     edges: option<array<option<fragment_friendsConnection_edges>>>,
   }
   type fragment = {
+    @live __id: RescriptRelay.dataId,
     friendsConnection: fragment_friendsConnection,
-    @live id: string,
   }
 }
 
@@ -25,7 +24,7 @@ module Internal = {
   type fragmentRaw
   @live
   let fragmentConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"__root":{"friendsConnection_edges_node":{"f":""}}}`
+    json`{}`
   )
   @live
   let fragmentConverterMap = ()
@@ -40,22 +39,24 @@ module Internal = {
 type t
 type fragmentRef
 external getFragmentRef:
-  RescriptRelay.fragmentRefs<[> | #TestPaginationInNode_query]> => fragmentRef = "%identity"
+  RescriptRelay.fragmentRefs<[> | #TestConnections_user]> => fragmentRef = "%identity"
 
 module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
   @inline
-  let connectionKey = "TestPaginationInNode_friendsConnection"
+  let connectionKey = "TestConnections_user_friendsConnection"
 
   %%private(
     @live @module("relay-runtime") @scope("ConnectionHandler")
-    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestPaginationInNode_friendsConnection") _, 'arguments) => RescriptRelay.dataId = "getConnectionID"
+    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestConnections_user_friendsConnection") _, 'arguments) => RescriptRelay.dataId = "getConnectionID"
   )
 
-  let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
-    let args = {"statuses": onlineStatuses}
+  let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: array<[#Online | #Idle | #Offline]>=[#Idle], ~beforeDate: TestsUtils.Datetime.t, ()) => {
+    let onlineStatuses = Some(onlineStatuses)
+    let beforeDate = Some(TestsUtils.Datetime.serialize(beforeDate))
+    let args = {"statuses": onlineStatuses, "beforeDate": beforeDate}
     internal_makeConnectionId(connectionParentDataId, args)
   }
   @live
@@ -75,21 +76,13 @@ type relayOperationNode
 type operationType = RescriptRelay.fragmentNode<relayOperationNode>
 
 
-%%private(let makeNode = (rescript_graphql_node_TestPaginationInNodeRefetchQuery): operationType => {
-  ignore(rescript_graphql_node_TestPaginationInNodeRefetchQuery)
-  %raw(json`(function(){
-var v0 = [
-  "friendsConnection"
-],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
-return {
+let node: operationType = %raw(json` {
   "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "beforeDate"
+    },
     {
       "defaultValue": 2,
       "kind": "LocalArgument",
@@ -101,7 +94,9 @@ return {
       "name": "cursor"
     },
     {
-      "defaultValue": null,
+      "defaultValue": [
+        "Idle"
+      ],
       "kind": "LocalArgument",
       "name": "onlineStatuses"
     }
@@ -113,30 +108,22 @@ return {
         "count": "count",
         "cursor": "cursor",
         "direction": "forward",
-        "path": (v0/*: any*/)
+        "path": [
+          "friendsConnection"
+        ]
       }
-    ],
-    "refetch": {
-      "connection": {
-        "forward": {
-          "count": "count",
-          "cursor": "cursor"
-        },
-        "backward": null,
-        "path": (v0/*: any*/)
-      },
-      "fragmentPathInResult": [
-        "node"
-      ],
-      "operation": rescript_graphql_node_TestPaginationInNodeRefetchQuery,
-      "identifierField": "id"
-    }
+    ]
   },
-  "name": "TestPaginationInNode_query",
+  "name": "TestConnections_user",
   "selections": [
     {
       "alias": "friendsConnection",
       "args": [
+        {
+          "kind": "Variable",
+          "name": "beforeDate",
+          "variableName": "beforeDate"
+        },
         {
           "kind": "Variable",
           "name": "statuses",
@@ -145,7 +132,7 @@ return {
       ],
       "concreteType": "UserConnection",
       "kind": "LinkedField",
-      "name": "__TestPaginationInNode_friendsConnection_connection",
+      "name": "__TestConnections_user_friendsConnection_connection",
       "plural": false,
       "selections": [
         {
@@ -164,11 +151,12 @@ return {
               "name": "node",
               "plural": false,
               "selections": [
-                (v1/*: any*/),
                 {
+                  "alias": null,
                   "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "TestPaginationInNode_user"
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
                 },
                 {
                   "alias": null,
@@ -218,12 +206,20 @@ return {
       ],
       "storageKey": null
     },
-    (v1/*: any*/)
+    {
+      "kind": "ClientExtension",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__id",
+          "storageKey": null
+        }
+      ]
+    }
   ],
   "type": "User",
   "abstractKey": null
-};
-})()`)
-})
-let node: operationType = makeNode(TestPaginationInNodeRefetchQuery_graphql.node)
+} `)
 

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -101,18 +92,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: unit => unit = ""

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequiredPlural_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -51,18 +42,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragmentRequired_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -51,18 +42,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_allowUnsafeEnum_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -55,18 +46,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_inline_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_inline_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -51,18 +42,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_plural_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -53,18 +44,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestFragment_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -53,18 +44,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -247,18 +238,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: unit => unit = ""

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayloadViaNodeInterfaceQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -258,18 +249,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestLocalPayload_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -155,18 +146,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationInline_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationInline_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -53,18 +44,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
@@ -4,35 +4,14 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
-  @live
-  type rec setOnlineStatusInput = {
-    onlineStatus: [
-      | #Idle
-      | #Offline
-      | #Online
-    ],
-    recursed: option<recursiveSetOnlineStatusInput>,
-  }
-  @live
-  and recursiveSetOnlineStatusInput = {
-    setOnlineStatus: option<setOnlineStatusInput>,
-    someValue: TestsUtils.IntString.t,
-  }
+  @live type setOnlineStatusInput = RelaySchemaAssets_graphql.input_SetOnlineStatusInput
+  @live type recursiveSetOnlineStatusInput = RelaySchemaAssets_graphql.input_RecursiveSetOnlineStatusInput
   @live
   type rec response_setOnlineStatusComplex_user = {
     @live id: string,
@@ -108,18 +87,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external make_setOnlineStatusInput: (

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusMutation_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -137,18 +128,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationWithInlineFragmentSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationWithInlineFragmentSetOnlineStatusMutation_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -134,18 +125,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationWithOnlyFragmentSetOnlineStatusMutation_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -180,18 +171,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutation_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -91,18 +82,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNodeRefetchQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -122,18 +113,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationInNode_query_graphql.res
@@ -49,7 +49,15 @@ module Utils = {
   @inline
   let connectionKey = "TestPaginationInNode_friendsConnection"
 
+  %%private(
+    @live @module("relay-runtime") @scope("ConnectionHandler")
+    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestPaginationInNode_friendsConnection") _, 'arguments) => RescriptRelay.dataId = "getConnectionId"
+  )
 
+  let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+    let args = {"statuses": onlineStatuses}
+    internal_makeConnectionId(connectionParentDataId, args)
+  }
   @live
   let getConnectionNodes: fragment_friendsConnection => array<fragment_friendsConnection_edges_node> = connection => 
     switch connection.edges {

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnionRefetchQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -117,18 +108,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
@@ -96,7 +96,7 @@ module Utils = {
 
   %%private(
     @live @module("relay-runtime") @scope("ConnectionHandler")
-    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestPaginationUnion_query_members") _, 'arguments) => RescriptRelay.dataId = "getConnectionId"
+    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestPaginationUnion_query_members") _, 'arguments) => RescriptRelay.dataId = "getConnectionID"
   )
 
   let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: string, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {

--- a/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestPaginationUnion_query_graphql.res
@@ -94,7 +94,16 @@ module Utils = {
   @inline
   let connectionKey = "TestPaginationUnion_query_members"
 
+  %%private(
+    @live @module("relay-runtime") @scope("ConnectionHandler")
+    external internal_makeConnectionId: (RescriptRelay.dataId, @as("TestPaginationUnion_query_members") _, 'arguments) => RescriptRelay.dataId = "getConnectionId"
+  )
 
+  let makeConnectionId = (connectionParentDataId: RescriptRelay.dataId, ~groupId: string, ~onlineStatuses: option<array<[#Online | #Idle | #Offline]>>=?, ()) => {
+    let groupId = Some(groupId)
+    let args = {"groupId": groupId, "onlineStatuses": onlineStatuses}
+    internal_makeConnectionId(connectionParentDataId, args)
+  }
   @live
   let getConnectionNodes: option<fragment_members> => array<fragment_members_edges_node> = connection => 
     switch connection {

--- a/packages/rescript-relay/__tests__/__generated__/TestQueryInputObjectsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestQueryInputObjectsQuery_graphql.res
@@ -4,12 +4,7 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  @live
-  type rec searchInput = {
-    @live id: int,
-    names: option<array<option<string>>>,
-    someOtherId: option<float>,
-  }
+  @live type searchInput = RelaySchemaAssets_graphql.input_SearchInput
   type response = {
     search: option<string>,
   }

--- a/packages/rescript-relay/__tests__/__generated__/TestQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -115,18 +106,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -112,18 +103,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNodeRefetchQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -118,18 +109,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingInNode_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -56,18 +47,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetchingRefetchQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -118,18 +109,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestRefetching_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -56,18 +47,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscriptionUserUpdatedSubscription_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -76,18 +67,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: (

--- a/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestSubscription_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -53,18 +44,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragmentUser_user_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -51,18 +42,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_member_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -86,18 +77,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionFragment_plural_member_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -87,18 +78,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestUnionsQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestUnionsQuery_graphql.res
@@ -4,18 +4,9 @@
 module Types = {
   @@ocaml.warning("-30")
 
-  type enum_OnlineStatus = private [>
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus = RelaySchemaAssets_graphql.enum_OnlineStatus
 
-  @live
-  type enum_OnlineStatus_input = [
-      | #Idle
-      | #Offline
-      | #Online
-    ]
+  type enum_OnlineStatus_input = RelaySchemaAssets_graphql.enum_OnlineStatus_input
 
 
 
@@ -177,18 +168,18 @@ module Utils = {
   @@ocaml.warning("-33")
   open Types
   @live
-  external onlineStatus_toString: enum_OnlineStatus => string = "%identity"
+  external onlineStatus_toString: RelaySchemaAssets_graphql.enum_OnlineStatus => string = "%identity"
   @live
-  external onlineStatus_input_toString: enum_OnlineStatus_input => string = "%identity"
+  external onlineStatus_input_toString: RelaySchemaAssets_graphql.enum_OnlineStatus_input => string = "%identity"
   @live
-  let onlineStatus_decode = (enum: enum_OnlineStatus): option<enum_OnlineStatus_input> => {
+  let onlineStatus_decode = (enum: RelaySchemaAssets_graphql.enum_OnlineStatus): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     switch enum {
-      | #...enum_OnlineStatus_input as valid => Some(valid)
+      | #...RelaySchemaAssets_graphql.enum_OnlineStatus_input as valid => Some(valid)
       | _ => None
     }
   }
   @live
-  let onlineStatus_fromString = (str: string): option<enum_OnlineStatus_input> => {
+  let onlineStatus_fromString = (str: string): option<RelaySchemaAssets_graphql.enum_OnlineStatus_input> => {
     onlineStatus_decode(Obj.magic(str))
   }
   @live @obj external makeVariables: unit => unit = ""

--- a/packages/rescript-relay/__tests__/schema.graphql
+++ b/packages/rescript-relay/__tests__/schema.graphql
@@ -1,6 +1,29 @@
 scalar Datetime
 scalar IntString
 
+input InputA {
+  time: Datetime!
+  recursiveA: InputA
+  usingB: InputB
+}
+
+"""
+A fine input.
+"""
+input InputB {
+  time: Datetime
+  usingA: InputA
+  constraint: Boolean # Reserved word
+}
+
+input SomeInput {
+  str: String
+  bool: Boolean
+  float: Float
+  int: Int
+  recursive: SomeInput
+}
+
 interface Node {
   id: ID!
 }
@@ -12,10 +35,17 @@ type PageInfo {
   endCursor: String
 }
 
+"""
+Whether something is online or not.
+"""
 enum OnlineStatus {
   Online
   Idle
   Offline
+}
+
+interface HasName {
+  name: String!
 }
 
 type User implements Node {
@@ -30,16 +60,19 @@ type User implements Node {
   friends(beforeDate: Datetime): [User!]!
   friendsConnection(
     statuses: [OnlineStatus!]
+    beforeDate: Datetime
+    name: String
     after: String
     first: Int
     before: String
     last: Int
+    objTest: SomeInput
   ): UserConnection!
   memberOf: [Member]
   memberOfSingular: Member
 }
 
-type Group implements Node {
+type Group implements Node & HasName {
   id: ID!
   name: String!
   avatarUrl: String
@@ -97,6 +130,10 @@ type SetOnlineStatusPayload {
   user: User
 }
 
+type TestIntInputPayload {
+  success: Boolean
+}
+
 input RecursiveSetOnlineStatusInput {
   someValue: IntString!
   setOnlineStatus: SetOnlineStatusInput
@@ -111,6 +148,17 @@ input SearchInput {
   names: [String]
   id: Int!
   someOtherId: Float
+}
+
+input PesticideListSearchInput {
+  companyName: [String!]
+  pesticideIds: [Int!]
+  skip: Int!
+  take: Int!
+}
+
+type RecursiveInputPayload {
+  recursionIsCool: Boolean
 }
 
 type Query {
@@ -133,14 +181,19 @@ type Query {
     last: Int
   ): UserConnection
   search(input: SearchInput!): String
+  searchPesticie(input: PesticideListSearchInput!): String
 }
 
 type Mutation {
   updateUserAvatar(avatarUrl: String): UpdateUserAvatarPayload
   addFriend(friendId: ID!): AddFriendPayload
   removeFriend(friendId: ID!): RemoveFriendPayload
+  testIntInput1(id: Int!): TestIntInputPayload
+  testIntInput2(ids: [Int!]!): TestIntInputPayload
+  testIntInput3(ids: [String!]!): TestIntInputPayload
   setOnlineStatus(onlineStatus: OnlineStatus!): SetOnlineStatusPayload
   setOnlineStatusComplex(input: SetOnlineStatusInput!): SetOnlineStatusPayload
+  recursiveInput(input: InputA): RecursiveInputPayload
 }
 
 type Subscription {

--- a/rescript-relay-documentation/docs/enums.md
+++ b/rescript-relay-documentation/docs/enums.md
@@ -112,6 +112,10 @@ switch TicketFragment.ticketStatus_fromString(someString) {
 
 This can be really handy when working with URL parameters, storage, or any other place where you need to go back and forth between your enum and strings.
 
+## Types for all enums in the schema
+
+All enums in your schema will have types emitted into the global `RelaySchemaAssets_graphql.res` file. This is handy if you want to use your enums elsewhere in your application, without necessarily being in a specific Relay context where you've selected that particular enum.
+
 ## Wrapping up
 
 Now you know all about enums in RescriptRelay!

--- a/rescript-relay-documentation/docs/input-objects.md
+++ b/rescript-relay-documentation/docs/input-objects.md
@@ -1,0 +1,9 @@
+---
+id: input-objects
+title: Input Objects
+sidebar_label: Input Objects
+---
+
+## Input objects in RescriptRelay
+
+All input objects in your schema will have their types (and maker functions) emitted into the generated file `RelaySchemaAssets_graphql.res`. This means you'll have access to the type definition of all of your input objects regardless of what you're doing. Handy if you're for example making general functions to produce various input objects.

--- a/rescript-relay-documentation/sidebars.js
+++ b/rescript-relay-documentation/sidebars.js
@@ -23,6 +23,7 @@ module.exports = {
       "enums",
       "unions",
       "interfaces",
+      "input-objects",
       "interacting-with-the-store",
     ],
     "API Reference": ["api-reference", "relay-environment"],


### PR DESCRIPTION
Closes https://github.com/zth/rescript-relay/issues/379 
Closes https://github.com/zth/rescript-relay/issues/349

## Shared type definitions
This PR pulls the latest compiler fork, which now emits a `RelaySchemaAssets_graphql.res` file holding all input object types + enum definitions. This will make life easier for anyone looking to share makers or helpers involving input objects or enums, or who want to use those types outside of a specific Relay context.

## Type safe connection ID makers
Each fragment with a `@connection` annotation will now have a `makeConnectionId` function generated. This function will let you, in a type safe way, generate ID:s for that connection, that you can then use with the declarative directives for inserting nodes/edges after mutations, etc.

It's for the cases when selecting and passing the connections `__id` isn't feasible for various reasons.