### PR TITLE
stop mangling with JSON scalars as a field of a mutation input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+## Bug Fixes
+
+- Fix issue with custom scalar of JSON values being accidentally mangled https://github.com/zth/rescript-relay/pull/395 @tsnobip
+
 # 1.0.0
 
 _[Here's a commit showing a project being upgraded to this version](https://github.com/zth/rescript-relay/commit/5831c2f1f0f13eedc1cb60468c32fd32b2dc01d3)_

--- a/packages/rescript-relay/__tests__/Test_localPayload-tests.js
+++ b/packages/rescript-relay/__tests__/Test_localPayload-tests.js
@@ -7,13 +7,14 @@ const ReactTestUtils = require("react-dom/test-utils");
 const { test_query } = require("./Test_localPayload.bs");
 
 describe("LocalPayload", () => {
-  test("commiting a local payload works", async () => {
+  test("committing a local payload works", async () => {
     queryMock.mockQuery({
       name: "TestLocalPayloadQuery",
       variables: {},
       data: {
         loggedInUser: {
           id: "user-1",
+          onlineStatus: "Online",
           firstName: "First",
           avatarUrl: "avatar-url",
           memberOf: null,
@@ -42,6 +43,7 @@ describe("LocalPayload", () => {
       data: {
         loggedInUser: {
           id: "user-1",
+          onlineStatus: "Online",
           firstName: "First",
           avatarUrl: "avatar-url",
           memberOf: null,

--- a/packages/rescript-relay/__tests__/Test_mutation-tests.js
+++ b/packages/rescript-relay/__tests__/Test_mutation-tests.js
@@ -121,10 +121,20 @@ describe("Mutation", () => {
       variables: {
         input: {
           onlineStatus: "Idle",
+          someJsonValue: {
+            foo: null,
+            bar: [["Boz", ["other text"]]],
+            baz: "some string",
+          },
           recursed: {
             someValue: "100",
             setOnlineStatus: {
               onlineStatus: "Online",
+              someJsonValue: {
+                foo: null,
+                bar: [["Boz", ["other text"]]],
+                baz: "some string",
+              },
               recursed: {
                 someValue: "100",
               },

--- a/packages/rescript-relay/__tests__/Test_mutation.res
+++ b/packages/rescript-relay/__tests__/Test_mutation.res
@@ -84,6 +84,19 @@ module Test = {
     let data = Fragment.use(query.loggedInUser.fragmentRefs)
     let (mutate, isMutating) = Mutation.use()
     let (inlineStatus, setInlineStatus) = React.useState(_ => "-")
+    let someJsonValue =
+      [
+        ("foo", Js.Json.null),
+        (
+          "bar",
+          Js.Json.array([
+            Js.Json.array([Js.Json.string("Boz"), Js.Json.array([Js.Json.string("other text")])]),
+          ]),
+        ),
+        ("baz", Js.Json.string("some string")),
+      ]
+      ->Js.Dict.fromArray
+      ->Js.Json.object_
 
     <div>
       {React.string(
@@ -191,10 +204,12 @@ module Test = {
                 // recursive conversion would be broken.
                 ~input=make_setOnlineStatusInput(
                   ~onlineStatus=#Idle,
+                  ~someJsonValue,
                   ~recursed=make_recursiveSetOnlineStatusInput(
                     ~someValue=100,
                     ~setOnlineStatus=make_setOnlineStatusInput(
                       ~onlineStatus=#Online,
+                      ~someJsonValue,
                       ~recursed=make_recursiveSetOnlineStatusInput(~someValue=100, ()),
                       (),
                     ),

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -68,6 +68,7 @@ and input_RecursiveSetOnlineStatusInput = {
 @live
 and input_SetOnlineStatusInput = {
   onlineStatus: [#Online | #Idle | #Offline],
+  someJsonValue: Js.Json.t,
   recursed: option<input_RecursiveSetOnlineStatusInput>,
 }
 
@@ -129,6 +130,7 @@ external make_RecursiveSetOnlineStatusInput: (
 @live @obj
 external make_SetOnlineStatusInput: (
   ~onlineStatus: [#Online | #Idle | #Offline],
+  ~someJsonValue: Js.Json.t,
   ~recursed: input_RecursiveSetOnlineStatusInput=?,
   unit,
 ) => input_SetOnlineStatusInput = ""

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
@@ -30,7 +30,7 @@ module Types = {
 module Internal = {
   @live
   let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
-    json`{"recursiveSetOnlineStatusInput":{"someValue":{"c":"TestsUtils.IntString"},"setOnlineStatus":{"r":"setOnlineStatusInput"}},"setOnlineStatusInput":{"recursed":{"r":"recursiveSetOnlineStatusInput"}},"__root":{"input":{"r":"setOnlineStatusInput"}}}`
+    json`{"recursiveSetOnlineStatusInput":{"someValue":{"c":"TestsUtils.IntString"},"setOnlineStatus":{"r":"setOnlineStatusInput"}},"setOnlineStatusInput":{"someJsonValue":{"b":""},"recursed":{"r":"recursiveSetOnlineStatusInput"}},"__root":{"input":{"r":"setOnlineStatusInput"}}}`
   )
   @live
   let variablesConverterMap = {

--- a/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestMutationSetOnlineStatusComplexMutation_graphql.res
@@ -102,6 +102,7 @@ module Utils = {
       | #Online
     ],
     ~recursed: recursiveSetOnlineStatusInput=?,
+    ~someJsonValue: Js.Json.t,
     unit
   ) => setOnlineStatusInput = ""
 

--- a/packages/rescript-relay/__tests__/schema.graphql
+++ b/packages/rescript-relay/__tests__/schema.graphql
@@ -1,5 +1,6 @@
 scalar Datetime
 scalar IntString
+scalar JSON
 
 input InputA {
   time: Datetime!
@@ -155,6 +156,7 @@ input RecursiveSetOnlineStatusInput {
 
 input SetOnlineStatusInput {
   onlineStatus: OnlineStatus!
+  someJsonValue: JSON!
   recursed: RecursiveSetOnlineStatusInput
 }
 

--- a/packages/rescript-relay/relay.config.js
+++ b/packages/rescript-relay/relay.config.js
@@ -6,6 +6,7 @@ module.exports = {
   customScalars: {
     Datetime: "TestsUtils.Datetime",
     IntString: "TestsUtils.IntString",
+    JSON: "Js.Json.t",
   },
   featureFlags: {
     enable_relay_resolver_transform: true,


### PR DESCRIPTION
if the json is not mangled with, the test should pass.

This should be the desired for any scalar I think