### PR TITLE
Fix remove-unused-fields in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # master
 
+# 1.0.3
+
+## Bug Fixes
+
+- Fix the `remove-unused-fields` script for CI with Node.js version >14 in [#409](https://github.com/zth/rescript-relay/pull/409)
+
 # 1.0.2
 
 ## Bug Fixes

--- a/packages/rescript-relay-cli/commands/removeUnusedFieldsCommand.ts
+++ b/packages/rescript-relay-cli/commands/removeUnusedFieldsCommand.ts
@@ -55,7 +55,7 @@ export const addRemoveUnusedFieldsCommand = (program: Command) => {
 
         const spinner = ora("Analyzing ReScript project").start();
 
-        const p = cp.spawn("npx", ["reanalyze", "-dce"]);
+        const p = cp.spawn("npx", ["--yes", "reanalyze", "-dce"]);
 
         if (p.stdout == null) {
           console.error("Something went wrong.");


### PR DESCRIPTION
I've started working on updating the `node` version in CI from `14` to `16`.
But the lint script started failing because of `rescript-relay-cli remove-unused-fields --ci --verbose` exiting with code `1`. 
Here's the error with `debug` on:
<img width="684" alt="image" src="https://user-images.githubusercontent.com/49292466/203781863-e485f38e-84ff-44b3-b474-b746ded1ec91.png">

After looking at the source code, several hours of different tries, and multiple wild guesses, I've found the solution. It worked fine before because the `npx` with `node@14` doesn't have the prompt.

For some reason, I couldn't reproduce the error locally and only in CI, but I've tested the fix using https://pnpm.io/cli/patch, and it solved the problem.