### PR TITLE
Support null variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+## Improvements
+
+- Experimental support for allowing `null` in operation variables. Add `@rescriptRelayNullableVariables` to your operation (query, mutation, subscription) and you'll be allowed to pass `Js.Nullable.null` to your server. https://github.com/zth/rescript-relay/pull/426
+
 # 1.0.4
 
 ## Improvements

--- a/packages/rescript-relay/__tests__/Test_nullableVariables-tests.js
+++ b/packages/rescript-relay/__tests__/Test_nullableVariables-tests.js
@@ -23,10 +23,6 @@ describe("Mutation", () => {
 
     queryMock.mockQuery({
       name: "TestNullableVariablesMutation",
-      matchVariables: (v) => {
-        console.log(v);
-        return false;
-      },
       variables: {
         avatarUrl: null,
         someInput: {

--- a/packages/rescript-relay/__tests__/Test_nullableVariables-tests.js
+++ b/packages/rescript-relay/__tests__/Test_nullableVariables-tests.js
@@ -1,0 +1,53 @@
+require("@testing-library/jest-dom/extend-expect");
+const t = require("@testing-library/react");
+const React = require("react");
+const queryMock = require("./queryMock");
+const ReactTestUtils = require("react-dom/test-utils");
+
+const { test_nullableVariables } = require("./Test_nullableVariables.bs");
+
+describe("Mutation", () => {
+  test("variables can be null", async () => {
+    queryMock.mockQuery({
+      name: "TestNullableVariablesQuery",
+      data: {
+        loggedInUser: {
+          id: "user-1",
+          avatarUrl: "avatar-url-1",
+        },
+      },
+    });
+
+    t.render(test_nullableVariables());
+    await t.screen.findByText("Avatar url is avatar-url-1");
+
+    queryMock.mockQuery({
+      name: "TestNullableVariablesMutation",
+      matchVariables: (v) => {
+        console.log(v);
+        return false;
+      },
+      variables: {
+        avatarUrl: null,
+        someInput: {
+          int: null,
+        },
+      },
+      data: {
+        updateUserAvatar: {
+          user: {
+            id: "user-1",
+            avatarUrl: null,
+            someRandomArgField: "test",
+          },
+        },
+      },
+    });
+
+    ReactTestUtils.act(() => {
+      t.fireEvent.click(t.screen.getByText("Change avatar URL"));
+    });
+
+    await t.screen.findByText("Avatar url is -");
+  });
+});

--- a/packages/rescript-relay/__tests__/Test_nullableVariables.res
+++ b/packages/rescript-relay/__tests__/Test_nullableVariables.res
@@ -28,14 +28,16 @@ module Test = {
       {React.string("Avatar url is " ++ data.avatarUrl->Belt.Option.getWithDefault("-"))}
       <button
         onClick={_ => {
-          open Mutation
-          let variables = {
-            Mutation.Types.avatarUrl: Js.Nullable.null,
-            someInput: Js.Nullable.return({
-              RelaySchemaAssets_graphql.int: Js.Nullable.null,
-            }),
-          }
-          commitMutation(~environment, ~variables, ())->RescriptRelay.Disposable.ignore
+          Mutation.commitMutation(
+            ~environment,
+            ~variables={
+              avatarUrl: Js.Nullable.null,
+              someInput: Js.Nullable.return({
+                RelaySchemaAssets_graphql.int: Js.Nullable.null,
+              }),
+            },
+            (),
+          )->RescriptRelay.Disposable.ignore
         }}>
         {React.string("Change avatar URL")}
       </button>

--- a/packages/rescript-relay/__tests__/Test_nullableVariables.res
+++ b/packages/rescript-relay/__tests__/Test_nullableVariables.res
@@ -1,0 +1,60 @@
+module Query = %relay(`
+    query TestNullableVariablesQuery {
+      loggedInUser {
+        avatarUrl
+      }
+    }
+`)
+
+module Mutation = %relay(`
+    mutation TestNullableVariablesMutation($avatarUrl: String, $someInput: SomeInput) @rescriptRelayNullableVariables {
+      updateUserAvatar(avatarUrl: $avatarUrl) {
+        user {
+          avatarUrl
+          someRandomArgField(someInput: $someInput)
+        }
+      }
+    }
+`)
+
+module Test = {
+  @react.component
+  let make = () => {
+    let environment = RescriptRelay.useEnvironmentFromContext()
+    let query = Query.use(~variables=(), ())
+    let data = query.loggedInUser
+
+    <div>
+      {React.string("Avatar url is " ++ data.avatarUrl->Belt.Option.getWithDefault("-"))}
+      <button
+        onClick={_ => {
+          open Mutation
+          let variables = {
+            Mutation.Types.avatarUrl: Js.Nullable.null,
+            someInput: Js.Nullable.return({
+              RelaySchemaAssets_graphql.int: Js.Nullable.null,
+            }),
+          }
+          commitMutation(~environment, ~variables, ())->RescriptRelay.Disposable.ignore
+        }}>
+        {React.string("Change avatar URL")}
+      </button>
+    </div>
+  }
+}
+
+@live
+let test_nullableVariables = () => {
+  let network = RescriptRelay.Network.makePromiseBased(~fetchFunction=RelayEnv.fetchQuery, ())
+
+  let environment = RescriptRelay.Environment.make(
+    ~network,
+    ~store=RescriptRelay.Store.make(~source=RescriptRelay.RecordSource.make(), ()),
+    (),
+  )
+  ()
+
+  <TestProviders.Wrapper environment>
+    <Test />
+  </TestProviders.Wrapper>
+}

--- a/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/RelaySchemaAssets_graphql.res
@@ -37,6 +37,13 @@ type rec input_InputA = {
 }
 
 @live
+and input_InputA_nullable = {
+  time: TestsUtils.Datetime.t,
+  recursiveA?: Js.Nullable.t<input_InputA_nullable>,
+  usingB?: Js.Nullable.t<input_InputB_nullable>,
+}
+
+@live
 and input_InputB = {
   time: option<TestsUtils.Datetime.t>,
   usingA: option<input_InputA>,
@@ -44,9 +51,22 @@ and input_InputB = {
 }
 
 @live
+and input_InputB_nullable = {
+  time?: Js.Nullable.t<TestsUtils.Datetime.t>,
+  usingA?: Js.Nullable.t<input_InputA_nullable>,
+  @as("constraint") constraint_?: Js.Nullable.t<bool>,
+}
+
+@live
 and input_InputC = {
   intStr: TestsUtils.IntString.t,
   recursiveC: option<input_InputC>,
+}
+
+@live
+and input_InputC_nullable = {
+  intStr: TestsUtils.IntString.t,
+  recursiveC?: Js.Nullable.t<input_InputC_nullable>,
 }
 
 @live
@@ -61,9 +81,26 @@ and input_SomeInput = {
 }
 
 @live
+and input_SomeInput_nullable = {
+  str?: Js.Nullable.t<string>,
+  bool?: Js.Nullable.t<bool>,
+  float?: Js.Nullable.t<float>,
+  int?: Js.Nullable.t<int>,
+  datetime?: Js.Nullable.t<TestsUtils.Datetime.t>,
+  recursive?: Js.Nullable.t<input_SomeInput_nullable>,
+  @as("private") private_?: Js.Nullable.t<bool>,
+}
+
+@live
 and input_RecursiveSetOnlineStatusInput = {
   someValue: TestsUtils.IntString.t,
   setOnlineStatus: option<input_SetOnlineStatusInput>,
+}
+
+@live
+and input_RecursiveSetOnlineStatusInput_nullable = {
+  someValue: TestsUtils.IntString.t,
+  setOnlineStatus?: Js.Nullable.t<input_SetOnlineStatusInput_nullable>,
 }
 
 @live
@@ -74,6 +111,13 @@ and input_SetOnlineStatusInput = {
 }
 
 @live
+and input_SetOnlineStatusInput_nullable = {
+  onlineStatus: [#Online | #Idle | #Offline],
+  someJsonValue: Js.Json.t,
+  recursed?: Js.Nullable.t<input_RecursiveSetOnlineStatusInput_nullable>,
+}
+
+@live
 and input_SearchInput = {
   names: option<array<option<string>>>,
   id: int,
@@ -81,9 +125,24 @@ and input_SearchInput = {
 }
 
 @live
+and input_SearchInput_nullable = {
+  names?: Js.Nullable.t<array<Js.Nullable.t<string>>>,
+  id: int,
+  someOtherId?: Js.Nullable.t<float>,
+}
+
+@live
 and input_PesticideListSearchInput = {
   companyName: option<array<string>>,
   pesticideIds: option<array<int>>,
+  skip: int,
+  take: int,
+}
+
+@live
+and input_PesticideListSearchInput_nullable = {
+  companyName?: Js.Nullable.t<array<string>>,
+  pesticideIds?: Js.Nullable.t<array<int>>,
   skip: int,
   take: int,
 }

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
@@ -1,0 +1,233 @@
+/* @sourceLoc Test_nullableVariables.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@ocaml.warning("-30")
+
+  @live type someInput = RelaySchemaAssets_graphql.input_SomeInput_nullable
+  @live
+  type rec response_updateUserAvatar_user = {
+    avatarUrl: option<string>,
+    someRandomArgField: option<string>,
+  }
+  @live
+  and response_updateUserAvatar = {
+    user: option<response_updateUserAvatar_user>,
+  }
+  @live
+  type response = {
+    updateUserAvatar: option<response_updateUserAvatar>,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = {
+    avatarUrl?: Js.Nullable.t<string>,
+    someInput?: Js.Nullable.t<someInput>,
+  }
+}
+
+module Internal = {
+  @live
+  let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{"someInput":{"recursive":{"r":"someInput"},"datetime":{"c":"TestsUtils.Datetime"}},"__root":{"someInput":{"r":"someInput"}}}`
+  )
+  @live
+  let variablesConverterMap = {
+    "TestsUtils.Datetime": TestsUtils.Datetime.serialize,
+  }
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    Js.undefined
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    Js.null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    Js.undefined
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+module Utils = {
+  @@ocaml.warning("-33")
+  open Types
+  @live @obj external make_someInput: (
+    ~bool: bool=?,
+    ~datetime: TestsUtils.Datetime.t=?,
+    ~float: float=?,
+    ~int: int=?,
+    ~_private: bool=?,
+    ~recursive: someInput=?,
+    ~str: string=?,
+    unit
+  ) => someInput = ""
+
+
+  @live @obj external makeVariables: (
+    ~avatarUrl: string=?,
+    ~someInput: someInput=?,
+    unit
+  ) => variables = ""
+
+
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.mutationNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "avatarUrl"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "someInput"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "avatarUrl",
+    "variableName": "avatarUrl"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "avatarUrl",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "someInput",
+      "variableName": "someInput"
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "someRandomArgField",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestNullableVariablesMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateUserAvatarPayload",
+        "kind": "LinkedField",
+        "name": "updateUserAvatar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "TestNullableVariablesMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateUserAvatarPayload",
+        "kind": "LinkedField",
+        "name": "updateUserAvatar",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "User",
+            "kind": "LinkedField",
+            "name": "user",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "id",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9a78edc9246d901f0f8b29ef34b53df7",
+    "id": null,
+    "metadata": {},
+    "name": "TestNullableVariablesMutation",
+    "operationKind": "mutation",
+    "text": "mutation TestNullableVariablesMutation(\n  $avatarUrl: String\n  $someInput: SomeInput\n) {\n  updateUserAvatar(avatarUrl: $avatarUrl) {\n    user {\n      avatarUrl\n      someRandomArgField(someInput: $someInput)\n      id\n    }\n  }\n}\n"
+  }
+};
+})() `)
+
+

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesMutation_graphql.res
@@ -40,7 +40,7 @@ module Internal = {
   let convertVariables = v => v->RescriptRelay.convertObj(
     variablesConverter,
     variablesConverterMap,
-    Js.undefined
+    Js.null
   )
   @live
   type wrapResponseRaw

--- a/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesQuery_graphql.res
+++ b/packages/rescript-relay/__tests__/__generated__/TestNullableVariablesQuery_graphql.res
@@ -1,0 +1,159 @@
+/* @sourceLoc Test_nullableVariables.res */
+/* @generated */
+%%raw("/* @generated */")
+module Types = {
+  @@ocaml.warning("-30")
+
+  type rec response_loggedInUser = {
+    avatarUrl: option<string>,
+  }
+  type response = {
+    loggedInUser: response_loggedInUser,
+  }
+  @live
+  type rawResponse = response
+  @live
+  type variables = unit
+  @live
+  type refetchVariables = unit
+  @live let makeRefetchVariables = () => ()
+}
+
+module Internal = {
+  @live
+  let variablesConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let variablesConverterMap = ()
+  @live
+  let convertVariables = v => v->RescriptRelay.convertObj(
+    variablesConverter,
+    variablesConverterMap,
+    Js.undefined
+  )
+  @live
+  type wrapResponseRaw
+  @live
+  let wrapResponseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let wrapResponseConverterMap = ()
+  @live
+  let convertWrapResponse = v => v->RescriptRelay.convertObj(
+    wrapResponseConverter,
+    wrapResponseConverterMap,
+    Js.null
+  )
+  @live
+  type responseRaw
+  @live
+  let responseConverter: Js.Dict.t<Js.Dict.t<Js.Dict.t<string>>> = %raw(
+    json`{}`
+  )
+  @live
+  let responseConverterMap = ()
+  @live
+  let convertResponse = v => v->RescriptRelay.convertObj(
+    responseConverter,
+    responseConverterMap,
+    Js.undefined
+  )
+  type wrapRawResponseRaw = wrapResponseRaw
+  @live
+  let convertWrapRawResponse = convertWrapResponse
+  type rawResponseRaw = responseRaw
+  @live
+  let convertRawResponse = convertResponse
+}
+
+type queryRef
+
+module Utils = {
+  @@ocaml.warning("-33")
+  open Types
+  @live @obj external makeVariables: unit => unit = ""
+}
+
+type relayOperationNode
+type operationType = RescriptRelay.queryNode<relayOperationNode>
+
+
+let node: operationType = %raw(json` (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "avatarUrl",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestNullableVariablesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestNullableVariablesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "loggedInUser",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d9322739175937b5325307d7d2c9d354",
+    "id": null,
+    "metadata": {},
+    "name": "TestNullableVariablesQuery",
+    "operationKind": "query",
+    "text": "query TestNullableVariablesQuery {\n  loggedInUser {\n    avatarUrl\n    id\n  }\n}\n"
+  }
+};
+})() `)
+
+include RescriptRelay.MakeLoadQuery({
+    type variables = Types.variables
+    type loadedQueryRef = queryRef
+    type response = Types.response
+    type node = relayOperationNode
+    let query = node
+    let convertVariables = Internal.convertVariables
+});


### PR DESCRIPTION
Closes https://github.com/zth/rescript-relay/issues/348

This introduces a directive `@rescriptRelayNullableVariables` on operations that will allow you to leverage `Js.Nullable.t` to send `null` explicitly to your APIs.

You can test this in your project by running `yarn add rescript-relay@support-nullable-variables`.

How it works in a nutshell:
```rescript
module Mutation = %relay(`
    mutation TestNullableVariablesMutation($avatarUrl: String) @rescriptRelayNullableVariables {
      updateUserAvatar(avatarUrl: $avatarUrl) {
        user {
          avatarUrl
        }
      }
    }
`)

// All optional variables in this operation can now be `null`, which will be preserved and sent to your server.
Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.Nullable.null}, ())

// Or if you want to send a value:
Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.Nullable.return("some-avatar-url")}, ())
```

This works for:
- Variables in queries/mutations/subscriptions.
- Input objects (they'll automatically be nullable when you use this directive)

The reason for this being an explicit directive and not applied globally is that this _isn't_ the default you want, working with options is still so much easier.

Notes:
- This is in a sense a "temporary" solution. I'll want to do a retake on this and a bunch of related things eventually. But that's more for a "RescriptRelay 2.0", and this will be the way to go for the foreseeable future.
- *Use this only if you really need it*.
- It doesn't work for refetch variables. That likely won't be covered until a "RescriptRelay 2.0".