### PR TITLE
Jsxv4 deferred ppx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - The signature for missing field handlers has changed. Previously you got an open type `{..}` as record, now instead you get a proper `RecordProxy.t` from the store. Check out [the changelog for Relay 15](https://github.com/facebook/relay/releases/tag/v15.0.0).
 - ReScript `>=10.1` and JSX v4 is now required.
+- Work around issue with JSX v4 and `%relay.deferredComponent`. You now need to annotate any component you want to use with `%relay.deferredComponent` with `@relay.deferredComponent`. https://github.com/zth/rescript-relay/pull/439
 
 ## Improvements
 

--- a/packages/rescript-relay/__tests__/RelayRouter.res
+++ b/packages/rescript-relay/__tests__/RelayRouter.res
@@ -1,0 +1,5 @@
+// Just to enable testing
+
+let useRegisterPreloadedAsset = (asset: RelayRouter__Types.preloadAsset) => {
+  ignore(asset)
+}

--- a/packages/rescript-relay/__tests__/RelayRouter__Types.res
+++ b/packages/rescript-relay/__tests__/RelayRouter__Types.res
@@ -1,0 +1,11 @@
+// Copied from the router, just to enable testing.
+type preloadComponentAsset = {
+  @as("__$rescriptChunkName__") chunk: string,
+  load: unit => unit,
+}
+
+@live
+type preloadAsset =
+  | Component(preloadComponentAsset)
+  | Image({url: string})
+  | Style({url: string})

--- a/packages/rescript-relay/__tests__/TestDeferredComponent.res
+++ b/packages/rescript-relay/__tests__/TestDeferredComponent.res
@@ -1,0 +1,4 @@
+@react.component
+let make = (~name) => {
+  React.string(name)
+}

--- a/packages/rescript-relay/__tests__/TestDeferredComponent.res
+++ b/packages/rescript-relay/__tests__/TestDeferredComponent.res
@@ -1,8 +1,4 @@
-@react.component
+@react.component @relay.deferredComponent
 let make = (~name) => {
   React.string(name)
-}
-
-module ExportedForDynamicImport__ = {
-  let make = make
 }

--- a/packages/rescript-relay/__tests__/TestDeferredComponent.res
+++ b/packages/rescript-relay/__tests__/TestDeferredComponent.res
@@ -1,3 +1,5 @@
+@@jsxConfig({version: 3})
+
 @react.component
 let make = (~name) => {
   React.string(name)

--- a/packages/rescript-relay/__tests__/TestDeferredComponent.res
+++ b/packages/rescript-relay/__tests__/TestDeferredComponent.res
@@ -1,6 +1,8 @@
-@@jsxConfig({version: 3})
-
 @react.component
 let make = (~name) => {
   React.string(name)
+}
+
+module ExportedForDynamicImport__ = {
+  let make = make
 }

--- a/packages/rescript-relay/__tests__/Test_deferredComponent.res
+++ b/packages/rescript-relay/__tests__/Test_deferredComponent.res
@@ -1,3 +1,4 @@
 module DeferredTest = %relay.deferredComponent(TestDeferredComponent.make)
 
+@@jsxConfig({version: 3})
 let jsx = <DeferredTest name="Name" />

--- a/packages/rescript-relay/__tests__/Test_deferredComponent.res
+++ b/packages/rescript-relay/__tests__/Test_deferredComponent.res
@@ -1,0 +1,3 @@
+module DeferredTest = %relay.deferredComponent(TestDeferredComponent.make)
+
+let jsx = <DeferredTest name="Name" />

--- a/packages/rescript-relay/__tests__/Test_deferredComponent.res
+++ b/packages/rescript-relay/__tests__/Test_deferredComponent.res
@@ -1,4 +1,3 @@
 module DeferredTest = %relay.deferredComponent(TestDeferredComponent.make)
 
-@@jsxConfig({version: 3})
 let jsx = <DeferredTest name="Name" />

--- a/packages/rescript-relay/rescript-relay-ppx/.ocamlformat
+++ b/packages/rescript-relay/rescript-relay-ppx/.ocamlformat
@@ -1,0 +1,11 @@
+profile = default
+version = 0.22.4
+
+field-space = tight-decl
+break-cases = toplevel
+module-item-spacing = preserve
+cases-exp-indent = 2
+space-around-arrays = false
+space-around-lists = false
+space-around-records = false
+space-around-variants = false

--- a/packages/rescript-relay/rescript-relay-ppx/library/DeferredComp.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/DeferredComp.re
@@ -23,8 +23,8 @@ let lazyExtension =
       let realLoc = loc;
       let loc = Ppxlib.Location.none
 
-      let moduleIdent =
-        Ppxlib.Ast_helper.Mod.ident(~loc, {txt: Lident(moduleName), loc});
+      let moduleIdentExported =
+        Ppxlib.Ast_helper.Mod.ident(~loc, {txt: Ldot(Lident(moduleName), "ExportedForDynamicImport__"), loc});
       
       let moduleIdentWithCorrectLoc =
         Ppxlib.Ast_helper.Mod.ident(~loc, {txt: Lident(moduleName), loc: realLoc});
@@ -40,7 +40,7 @@ let lazyExtension =
           // definition, hover etc all point to the dynamically imported module
           // rather than what the PPX produces.
           [%stri module M = [%m moduleIdentWithCorrectLoc]],
-          [%stri module type T = (module type of [%m moduleIdent])],
+          [%stri module type T = (module type of [%m moduleIdentExported])],
           [%stri
             [@val]
             external import_:
@@ -81,9 +81,6 @@ let lazyExtension =
               })
             }
           ],
-          [%stri let%private unsafePlaceholder: module T = [%raw {|{}|}]],
-          [%stri module UnsafePlaceholder = (val unsafePlaceholder)],
-          [%stri let makeProps = UnsafePlaceholder.makeProps],
           [%stri let component =  lazy_(loadReactComponent)],
           [%stri let make = (props) => {
             RelayRouter.useRegisterPreloadedAsset(

--- a/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
@@ -64,6 +64,5 @@ let () =
       DeferredComp.lazyExtension,
     ],
     ~preprocess_impl=Transform.structure_mapper,
-    ~preprocess_intf=Transform.signature_mapper,
     "rescript-relay",
   );

--- a/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
@@ -51,6 +51,10 @@ let commonExtension =
     },
   );
 
+
+
+
+
 // This registers all defined extension points to the "rescript-relay" ppx.
 let () =
   Driver.register_transformation(
@@ -59,5 +63,7 @@ let () =
       LazyComp.lazyExtension,
       DeferredComp.lazyExtension,
     ],
+    ~preprocess_impl=Transform.structure_mapper,
+    ~preprocess_intf=Transform.signature_mapper,
     "rescript-relay",
   );

--- a/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
+++ b/packages/rescript-relay/rescript-relay-ppx/library/RescriptRelayPpxLibrary.re
@@ -51,10 +51,6 @@ let commonExtension =
     },
   );
 
-
-
-
-
 // This registers all defined extension points to the "rescript-relay" ppx.
 let () =
   Driver.register_transformation(

--- a/packages/rescript-relay/rescript-relay-ppx/library/Transform.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Transform.ml
@@ -1,0 +1,51 @@
+open Ppxlib
+open Ast_helper
+
+class mapper =
+  object (self)
+    inherit Ast_traverse.map
+    method! signature signature =
+      signature |> List.map (fun v -> [v]) |> List.concat
+    method! structure structure =
+      structure
+      |> List.map (fun v ->
+             match v with
+             | {pstr_desc = Pstr_value (_, [{pvb_attributes}])}
+               when pvb_attributes
+                    |> List.exists (fun (name : attribute) ->
+                           name.attr_name.txt = "relay.deferredComponent") ->
+               [
+                 v;
+                 Str.mk
+                   (Pstr_module
+                      {
+                        pmb_name =
+                          {
+                            txt = Some "ExportedForDynamicImport__";
+                            loc = Location.none;
+                          };
+                        pmb_expr =
+                          Mod.structure
+                            [
+                              Str.value Nonrecursive
+                                [
+                                  Vb.mk
+                                    (Pat.var
+                                       {txt = "make"; loc = Location.none})
+                                    (Exp.ident
+                                       {
+                                         txt = Lident "make";
+                                         loc = Location.none;
+                                       });
+                                ];
+                            ];
+                        pmb_attributes = [];
+                        pmb_loc = Location.none;
+                      });
+               ]
+             | _ -> [v])
+      |> List.concat
+  end
+
+let structure_mapper s = (new mapper)#structure s
+let signature_mapper s = (new mapper)#signature s

--- a/packages/rescript-relay/rescript-relay-ppx/library/Transform.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Transform.ml
@@ -4,8 +4,6 @@ open Ast_helper
 class mapper =
   object (self)
     inherit Ast_traverse.map
-    method! signature signature =
-      signature |> List.map (fun v -> [v]) |> List.concat
     method! structure structure =
       structure
       |> List.map (fun v ->
@@ -48,4 +46,3 @@ class mapper =
   end
 
 let structure_mapper s = (new mapper)#structure s
-let signature_mapper s = (new mapper)#signature s


### PR DESCRIPTION
Works around JSXv4 issues for deferred components. You now need to annotate any component you want to use with `%relay.deferredComponent` with `@relay.deferredComponent`.