### PR TITLE
Support for ReScript v11 and @rescript/react v0.12

### DIFF
--- a/packages/rescript-relay/package.json
+++ b/packages/rescript-relay/package.json
@@ -39,8 +39,7 @@
     "test:ci": "jest --ci --runInBand"
   },
   "devDependencies": {
-    "rescript": "^10.1.3",
-    "@rescript/react": "0.11.0",
+    "@rescript/react": "0.12.0-alpha.2",
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^13.0.0-alpha.6",
     "bs-fetch": "^0.5.0",
@@ -51,7 +50,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-relay": "15.0.0",
-    "relay-runtime": "15.0.0"
+    "relay-runtime": "15.0.0",
+    "rescript": "11.0.0-alpha.6"
   },
   "peerDependencies": {
     "@rescript/react": "*",

--- a/packages/rescript-relay/src/ReactExperimental.resi
+++ b/packages/rescript-relay/src/ReactExperimental.resi
@@ -7,7 +7,7 @@ external useTransitionWithOptions: unit => (
   (. unit => unit, option<{"name": option<string>}>) => unit,
 ) = "useTransition"
 
-let useTransition: unit => (bool, React.callback<unit => unit, unit>)
+let useTransition: unit => (bool, (unit => unit) => unit)
 
 module SuspenseList: {
   @module("react") @react.component

--- a/packages/rescript-relay/yarn.lock
+++ b/packages/rescript-relay/yarn.lock
@@ -516,10 +516,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@rescript/react@0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@rescript/react/-/react-0.11.0.tgz#d2545546d823bdb8e6b59daa1790098d1666f79e"
-  integrity sha512-RzoAO+3cJwXE2D7yodMo4tBO2EkeDYCN/I/Sj/yRweI3S1CY1ZBOF/GMcVtjeIurJJt7KMveqQXTaRrqoGZBBg==
+"@rescript/react@0.12.0-alpha.2":
+  version "0.12.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@rescript/react/-/react-0.12.0-alpha.2.tgz#9a65668c6056ac1f80917639a96f4ad7887320f7"
+  integrity sha512-FkVFU7LFT0c9tT01N08VsbhE7X3IuJvxrTBrbCehRyhw3qZy2qq9+HmMWm87kD4jaO23J7OhCGz5ejf66YOyoQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -2595,10 +2595,10 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-rescript@^10.1.3:
-  version "10.1.3"
-  resolved "https://registry.yarnpkg.com/rescript/-/rescript-10.1.3.tgz#0ff208cef09ea1f8ad38efc171c4942eca72d444"
-  integrity sha512-5qaf63As6nkbrMRJ85kZ0ifLzKAGPOGLuoJ4zFVGZIp4oMePRt6bCKWAIX7zgbRDfRPa3jSu+EnoY2873gxaIA==
+rescript@11.0.0-alpha.6:
+  version "11.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/rescript/-/rescript-11.0.0-alpha.6.tgz#29f6fb79b77eed572048edaf35b78ba469fd346f"
+  integrity sha512-516p5A+ybndzdxjKbOVJNrSd+p+U3FZ5Lm9U7SfGREzJXKACY3e69dk9ey/wDO4fh6Ge8j+NIXhHOTjFhMx4sw==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR includes the following changes:
* Support for ReScript v11(currently v11-alpha.6)
* Support for rescript-react v0.12.0(currently v0.12.0-alpha.2)
	* Removed `Reac.callback` type in https://github.com/rescript-lang/rescript-react/pull/90

I'm going to follow up on subsequent changes to the compiler and rescript-relay here. This is in response to the latest ReScript v11 and rescript-react v0.12.0, so feel free to close it for reference.