### PR TITLE
avoid ENOENT error when rebuilding deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 # **Version 3**
 
+# 3.0.0-rc.4
+
+- Fix an error in postinstall.js when reinstalling rescript-relay dependency (https://github.com/zth/rescript-relay/pull/487)
+
 # 3.0.0-rc.3
 
 - Fix issue with custom scalars in arrays not being autoconverted properly.

--- a/packages/rescript-relay/scripts/release-postinstall.js
+++ b/packages/rescript-relay/scripts/release-postinstall.js
@@ -99,20 +99,16 @@ function copyPlatformBinaries(platform) {
   /**
    * Copy the PPX
    */
-  fs.copyFileSync(
-    path.join(__dirname, "ppx-" + platform),
-    path.join(__dirname, "ppx")
-  );
-  fs.chmodSync(path.join(__dirname, "ppx"), 0777);
+  const ppxFinalFilename = platform === "windows-latest" ? "ppx.exe" : "ppx";
+  const ppxFinalPath = path.join(__dirname, ppxFinalFilename);
 
-  // Windows seems to need an .exe file as well.
-  if (platform === "windows-latest") {
+  if (!fs.existsSync(ppxFinalPath)){
     fs.copyFileSync(
       path.join(__dirname, "ppx-" + platform),
-      path.join(__dirname, "ppx.exe")
+      ppxFinalPath
     );
-    fs.chmodSync(path.join(__dirname, "ppx.exe"), 0777);
   }
+  fs.chmodSync(ppxFinalPath, 0777);
 
   /**
    * Copy the Relay compiler
@@ -120,15 +116,19 @@ function copyPlatformBinaries(platform) {
 
   var platformSuffix = getRelayCompilerPlatformSuffix();
 
-  fs.copyFileSync(
-    path.join(
-      __dirname,
-      "relay-compiler-" + platformSuffix,
-      platformSuffix === "win-x64" ? "relay.exe" : "relay"
-    ),
-    path.join(__dirname, "rescript-relay-compiler.exe")
-  );
-  fs.chmodSync(path.join(__dirname, "rescript-relay-compiler.exe"), 0777);
+  const rescriptRelayCompilerFinalPath = path.join(__dirname, "rescript-relay-compiler.exe");
+
+  if (!fs.existsSync(rescriptRelayCompilerFinalPath)){
+    fs.copyFileSync(
+      path.join(
+        __dirname,
+        "relay-compiler-" + platformSuffix,
+        platformSuffix === "win-x64" ? "relay.exe" : "relay"
+      ),
+      rescriptRelayCompilerFinalPath
+    );
+  }
+  fs.chmodSync(rescriptRelayCompilerFinalPath, 0777);
 }
 
 function removeInitialBinaries() {


### PR DESCRIPTION
Without this fix, I frequently get the following error:

```
# This file contains the result of Yarn building a package (rescript-relay@virtual:d9ee19c7d21b51ab446d207037b2e76a866dce1033d055f68eea718d1aad4e8e07b9ebe79e1234ad68e9c3b88e667d22ab495f68c31bf24afd238dcea56f49b1#npm:3.0.0-rc.1)
# Script name: postinstall

node:fs:3003
  binding.copyFile(
          ^

Error: ENOENT: no such file or directory, copyfile '/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/ppx-macos-latest' -> '/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/ppx'
    at Object.copyFileSync (node:fs:3003:11)
    at copyPlatformBinaries (/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/postinstall.js:102:6)
    at Object.<anonymous> (/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/postinstall.js:177:7)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'copyfile',
  path: '/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/ppx-macos-latest',
  dest: '/Users/paul/code/miriad/packages/web/node_modules/rescript-relay/ppx'
}

Node.js v20.10.0
```