### PR TITLE
Patch postinstall.js number 2

### DIFF
--- a/packages/rescript-relay/scripts/release-postinstall.js
+++ b/packages/rescript-relay/scripts/release-postinstall.js
@@ -128,11 +128,17 @@ function copyPlatformBinaries(platform) {
   fs.chmodSync(rescriptRelayCompilerFinalPath, 0o777);
 }
 
+function unlinkIfNotExistsSync(path) {
+  if (fs.existsSync(path)) {
+    fs.unlinkSync(path);
+  }
+}
+
 function removeInitialBinaries() {
-  fs.unlinkSync(path.join(__dirname, "ppx-macos-arm64"));
-  fs.unlinkSync(path.join(__dirname, "ppx-macos-latest"));
-  fs.unlinkSync(path.join(__dirname, "ppx-windows-latest"));
-  fs.unlinkSync(path.join(__dirname, "ppx-linux"));
+  unlinkIfNotExistsSync(path.join(__dirname, "ppx-macos-arm64"));
+  unlinkIfNotExistsSync(path.join(__dirname, "ppx-macos-latest"));
+  unlinkIfNotExistsSync(path.join(__dirname, "ppx-windows-latest"));
+  unlinkIfNotExistsSync(path.join(__dirname, "ppx-linux"));
   fs.rmSync(path.join(__dirname, "relay-compiler-linux-x64"), {
     recursive: true,
     force: true,

--- a/packages/rescript-relay/scripts/release-postinstall.js
+++ b/packages/rescript-relay/scripts/release-postinstall.js
@@ -102,7 +102,7 @@ function copyPlatformBinaries(platform) {
   if (!fs.existsSync(ppxFinalPath)) {
     fs.copyFileSync(path.join(__dirname, "ppx-" + platform), ppxFinalPath);
   }
-  fs.chmodSync(ppxFinalPath, 0777);
+  fs.chmodSync(ppxFinalPath, 0o777);
 
   /**
    * Copy the Relay compiler
@@ -125,7 +125,7 @@ function copyPlatformBinaries(platform) {
       rescriptRelayCompilerFinalPath
     );
   }
-  fs.chmodSync(rescriptRelayCompilerFinalPath, 0777);
+  fs.chmodSync(rescriptRelayCompilerFinalPath, 0o777);
 }
 
 function removeInitialBinaries() {


### PR DESCRIPTION
I fixed the issue in copyPlatformBinaries earlier but I forgot to do it for removeInitialBinaries, now the postinstall script should be idempotent.