### PR TITLE
hide use and useOpt when @inline is given to a fragment

### DIFF
--- a/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
+++ b/packages/rescript-relay/rescript-relay-ppx/library/Fragment.ml
@@ -22,26 +22,31 @@ let make ~loc ~moduleName ~refetchableQueryName ~extractedConnectionInfo
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] ->
                     [%t typeFromGeneratedModule ["Types"; "fragment"]] =
                   [%e valFromGeneratedModule ["Internal"; "convertFragment"]]];
-              [%stri
-                let use fRef :
-                    [%t typeFromGeneratedModule ["Types"; "fragment"]] =
-                  RescriptRelay_Fragment.useFragment ~convertFragment
-                    ~fRef:
-                      (fRef |. [%e valFromGeneratedModule ["getFragmentRef"]])
-                    ~node:[%e valFromGeneratedModule ["node"]]];
-              [%stri
-                let useOpt fRef :
-                    [%t typeFromGeneratedModule ["Types"; "fragment"]] option =
-                  RescriptRelay_Fragment.useFragmentOpt ~convertFragment
-                    ~fRef:
-                      (match fRef with
-                      | Some fRef ->
-                        Some
-                          (fRef
-                          |. [%e valFromGeneratedModule ["getFragmentRef"]])
-                      | None -> None)
-                    ~node:[%e valFromGeneratedModule ["node"]]];
             ];
+            (match hasInlineDirective with
+            | false ->
+              [
+                [%stri
+                  let use fRef :
+                      [%t typeFromGeneratedModule ["Types"; "fragment"]] =
+                    RescriptRelay_Fragment.useFragment ~convertFragment
+                      ~fRef:
+                        (fRef |. [%e valFromGeneratedModule ["getFragmentRef"]])
+                      ~node:[%e valFromGeneratedModule ["node"]]];
+                [%stri
+                  let useOpt fRef :
+                      [%t typeFromGeneratedModule ["Types"; "fragment"]] option =
+                    RescriptRelay_Fragment.useFragmentOpt ~convertFragment
+                      ~fRef:
+                        (match fRef with
+                        | Some fRef ->
+                          Some
+                            (fRef
+                            |. [%e valFromGeneratedModule ["getFragmentRef"]])
+                        | None -> None)
+                      ~node:[%e valFromGeneratedModule ["node"]]];
+              ]
+            | true -> []);
             (match hasInlineDirective with
             | true ->
               [


### PR DESCRIPTION
[The CI seems unhappy with compiling the rust project](https://github.com/ValdemarGr/rescript-relay/actions/runs/8929383024/job/24527042667)