### PR TITLE
Update docs reflecting v3 changes

### DIFF
--- a/rescript-relay-documentation/docs/api-reference.md
+++ b/rescript-relay-documentation/docs/api-reference.md
@@ -185,7 +185,7 @@ Use it like this: `makeArguments({ "someArgument": someValue, "anotherArgument":
 ## [generateClientID](#generateclientid)
 
 ```rescript
-let generateClientID: (~dataId: dataId, ~storageKey: string, ~index: int=?, unit) => dataId
+let generateClientID: (~dataId: dataId, ~storageKey: string, ~index: int=?) => dataId
 ```
 
 > Read more about: [dataId](#dataid)
@@ -320,8 +320,7 @@ Read the following section on working with the Relay store: https://relay.dev/do
 let getLinkedRecords: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => option<array<option<t>>>
 ```
 
@@ -352,7 +351,7 @@ Gets the [dataId](#dataid) for a particular record.
 ### [RecordProxy.getLinkedRecord](#recordproxygetlinkedrecord)
 
 ```rescript
-let getLinkedRecord: (t, ~name: string, ~arguments: arguments=?, unit) => option<t>
+let getLinkedRecord: (t, ~name: string, ~arguments: arguments=?) => option<t>
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -366,8 +365,7 @@ let getOrCreateLinkedRecord: (
     t,
     ~name: string,
     ~typeName: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -388,7 +386,7 @@ Returns the `__typename` of this particular record.
 ### [RecordProxy.getValueString](#recordproxygetvaluestring)
 
 ```rescript
-let getValueString: (t, ~name: string, ~arguments: arguments=?, unit) => option<string>
+let getValueString: (t, ~name: string, ~arguments: arguments=?) => option<string>
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -401,8 +399,7 @@ Returns a field value, expecting it to be a string.
 let getValueStringArray: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => option<array<option<string>>>
 ```
 
@@ -413,7 +410,7 @@ Returns a field value, expecting it to be an array of strings.
 ### [RecordProxy.getValueInt](#recordproxygetvalueint)
 
 ```rescript
-let getValueInt: (t, ~name: string, ~arguments: arguments=?, unit) => option<int>
+let getValueInt: (t, ~name: string, ~arguments: arguments=?) => option<int>
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -426,8 +423,7 @@ Returns a field value, expecting it to be an int.
 let getValueIntArray: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => option<array<option<int>>>
 ```
 
@@ -438,7 +434,7 @@ Returns a field value, expecting it to be an array of ints.
 ### [RecordProxy.getValueFloat](#recordproxygetvaluefloat)
 
 ```rescript
-let getValueFloat: (t, ~name: string, ~arguments: arguments=?, unit) => option<float>
+let getValueFloat: (t, ~name: string, ~arguments: arguments=?) => option<float>
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -451,8 +447,7 @@ Returns a field value, expecting it to be a float.
 let getValueFloatArray: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => option<array<option<float>>>
 ```
 
@@ -463,7 +458,7 @@ Returns a field value, expecting it to be an array of floats.
 ### [RecordProxy.getValueBool](#recordproxygetvaluebool)
 
 ```rescript
-let getValueBool: (t, ~name: string, ~arguments: arguments=?, unit) => option<bool>
+let getValueBool: (t, ~name: string, ~arguments: arguments=?) => option<bool>
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -476,8 +471,7 @@ Returns a field value, expecting it to be a boolean.
 let getValueBoolArray: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => option<array<option<bool>>>
 ```
 
@@ -488,7 +482,7 @@ Returns a field value, expecting it to be an array of booleans.
 ### [RecordProxy.setLinkedRecord](#recordproxysetlinkedrecord)
 
 ```rescript
-let setLinkedRecord: (t, ~record: t, ~name: string, ~arguments: arguments=?, unit) => t
+let setLinkedRecord: (t, ~record: t, ~name: string, ~arguments: arguments=?) => t
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -502,8 +496,7 @@ let setLinkedRecords: (
     t,
     ~records: array<option<t>>,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -514,7 +507,7 @@ Sets an array of [RecordProxy.t](#recordproxyt) as the linked records for a part
 ### [RecordProxy.setValueString](#recordproxysetvaluestring)
 
 ```rescript
-let setValueString: (t, ~value: string, ~name: string, ~arguments: arguments=?, unit) => t
+let setValueString: (t, ~value: string, ~name: string, ~arguments: arguments=?) => t
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -528,8 +521,7 @@ let setValueStringArray: (
     t,
     ~value: array<string>,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -540,7 +532,7 @@ Sets an array of strings as field value.
 ### [RecordProxy.setValueInt](#recordproxysetvalueint)
 
 ```rescript
-let setValueInt: (t, ~value: int, ~name: string, ~arguments: arguments=?, unit) => t
+let setValueInt: (t, ~value: int, ~name: string, ~arguments: arguments=?) => t
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -554,8 +546,7 @@ let setValueIntArray: (
     t,
     ~value: array<int>,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -566,7 +557,7 @@ Sets an array of ints as field value.
 ### [RecordProxy.setValueFloat](#recordproxysetvaluefloat)
 
 ```rescript
-let setValueFloat: (t, ~value: float, ~name: string, ~arguments: arguments=?, unit) => t
+let setValueFloat: (t, ~value: float, ~name: string, ~arguments: arguments=?) => t
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -580,8 +571,7 @@ let setValueFloatArray: (
     t,
     ~value: array<float>,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -592,7 +582,7 @@ Sets an array of floats as field value.
 ### [RecordProxy.setValueBool](#recordproxysetvaluebool)
 
 ```rescript
-let setValueBool: (t, ~value: bool, ~name: string, ~arguments: arguments=?, unit) => t
+let setValueBool: (t, ~value: bool, ~name: string, ~arguments: arguments=?) => t
 ```
 
 > Read more about: [RecordProxy.t](#recordproxyt), [arguments](#arguments)
@@ -606,8 +596,7 @@ let setValueBoolArray: (
     t,
     ~value: array<bool>,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -621,8 +610,7 @@ Sets an array of booleans as field value.
 let setValueToUndefined: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -636,8 +624,7 @@ Sets the field value to `undefined` (meaning Relay will treat it as missing data
 let setValueToNull: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -651,8 +638,7 @@ Sets the field value to `null`.
 let setLinkedRecordToUndefined: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -666,8 +652,7 @@ Sets this linked record to `undefined` (meaning Relay will treat it as missing d
 let setLinkedRecordToNull: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -681,8 +666,7 @@ Sets this linked record to `null`.
 let setLinkedRecordsToUndefined: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -696,8 +680,7 @@ Sets the field holding these linked records to `undefined` (meaning Relay will t
 let setLinkedRecordsToNull: (
     t,
     ~name: string,
-    ~arguments: arguments=?,
-    unit,
+    ~arguments: arguments=?
   ) => t
 ```
 
@@ -811,8 +794,7 @@ Read the Relay docs section on [ConnectionHandler](https://relay.dev/docs/en/rel
 let getConnection: (
     ~record: RecordProxy.t,
     ~key: string,
-    ~filters: arguments=?,
-    unit,
+    ~filters: arguments=?
   ) => option<RecordProxy.t>
 ```
 
@@ -841,8 +823,7 @@ Creates an edge for a particular connection.
 let insertEdgeBefore: (
     ~connection: RecordProxy.t,
     ~newEdge: RecordProxy.t,
-    ~cursor: string=?,
-    unit,
+    ~cursor: string=?
   ) => unit
 ```
 
@@ -856,8 +837,7 @@ Inserts an edge into a connection _before_ the provided cursor. If no cursor is 
 let insertEdgeAfter: (
     ~connection: RecordProxy.t,
     ~newEdge: RecordProxy.t,
-    ~cursor: string=?,
-    unit,
+    ~cursor: string=?
   ) => unit
 ```
 
@@ -898,8 +878,7 @@ let makeObserver: (
     ~next: 'response => unit=?,
     ~error: Js.Exn.t => unit=?,
     ~complete: unit => unit=?,
-    ~unsubscribe: subscription => unit=?,
-    unit,
+    ~unsubscribe: subscription => unit=?
   ) => observer<'response>
 ```
 
@@ -1001,8 +980,7 @@ The type representing an instantiated `NetworkLayer`.
 ```rescript
 let makePromiseBased: (
     ~fetchFunction: fetchFunctionPromise,
-    ~subscriptionFunction: subscribeFn=?,
-    unit,
+    ~subscriptionFunction: subscribeFn=?
   ) => t
 ```
 
@@ -1015,8 +993,7 @@ The type representing an instantiated `NetworkLayer`.
 ```rescript
 let makeObservableBased: (
     ~observableFunction: fetchFunctionObservable,
-    ~subscriptionFunction: subscribeFn=?,
-    unit,
+    ~subscriptionFunction: subscribeFn=?
   ) => t
 ```
 
@@ -1075,8 +1052,7 @@ let make: (
     ~source: RecordSource.t,
     ~gcReleaseBufferSize: /* `gcReleaseBufferSize` controls how many queries are allowed to be cached by default. Increase this to increase the size of the cache. */
     int=?,
-    ~queryCacheExpirationTime: int /* `queryCacheExpirationTime` sets a TTL (time to live) for all queries. If that time passes, the data is considered stale and is evicted from the store. Default is no TTL. */=?,
-    unit,
+    ~queryCacheExpirationTime: int /* `queryCacheExpirationTime` sets a TTL (time to live) for all queries. If that time passes, the data is considered stale and is evicted from the store. Default is no TTL. */=?
   ) => t
 ```
 
@@ -1114,7 +1090,7 @@ let make = (~serializedRecords: RescriptRelay.recordSourceRecords) => {
   let environment = RescriptRelay.useEnvironmentFromContext()
 
   /* Make sure we only run this once */
-  React.useEffect2(() => {
+  React.useEffect(() => {
     /* This will publish the records to the existing store */
     environment->RescriptRelay.Store.publish(serializedRecords)
     None
@@ -1218,8 +1194,7 @@ let make: (
       ~typeName: string,
     ) => string=?,
     ~treatMissingFieldsAsNull: bool=?,
-    ~missingFieldHandlers: array<MissingFieldHandler.t>=?,
-    unit,
+    ~missingFieldHandlers: array<MissingFieldHandler.t>=?
   ) => t
 ```
 

--- a/rescript-relay-documentation/docs/enums.md
+++ b/rescript-relay-documentation/docs/enums.md
@@ -79,7 +79,7 @@ let (newStatus, setNewStatus) = React.useState(() => ticket.status)
 // Uh-oh, we can't do this because we can't guarantee that `ticket.status` above,
 // which is assigned to `newStatus`, is the values we expect it to be, since
 // the server might've changed the enum members after we've deployed.
-setTicketStatus(~variables={id: ticket.id, newStatus: newStatus}, ()))
+setTicketStatus(~variables={id: ticket.id, newStatus: newStatus})
 ```
 
 Luckily, RescriptRelay gives you utils to deal with this situation. Whenever you want to move between the _unsafe_ enum coming directly from the server, and a _safe_ version of that enum that you know is correct, you can use `<enumName>_decode`. This will validate that the enum that came from the server is in fact in the shape you expect. The same example as above, but now ensuring that the enum in the state is actually what we want it to be:
@@ -93,7 +93,7 @@ let (newStatus, setNewStatus) = React.useState(() =>
   // sets a default value instead.
   ticket.status
     ->TicketFragment.ticketStatus_decode
-    ->Belt.Option.getWithDefault(#OnHold)
+    ->Option.getOr(#OnHold)
   )
 
 // Yay, `newStatus` is now safe to use like we expect it to be!

--- a/rescript-relay-documentation/docs/making-queries.md
+++ b/rescript-relay-documentation/docs/making-queries.md
@@ -41,8 +41,7 @@ let make = (~userId) => {
   let queryData = Query.use(
     ~variables={
       userId: userId,
-    },
-    (),
+    }
   )
 
   switch queryData.userById {
@@ -72,7 +71,7 @@ RescriptRelay lets you leverage preloading in 3 different ways, all suitable for
 In RescriptRelay, every `%relay()` node containing a query automatically generates a `useLoader` hook. That hook returns a tuple of 3 things: `(option<queryRef>, loadQuery, disposeQuery)`.
 
 1. `option<queryRef>` - an option of a query reference. This query reference can be passed to `Query.usePreloaded`, like `let queryData = Query.usePreloaded(~queryRef=queryRef)`, to get the data for the query as soon as it's available.
-2. `loadQuery` - a function that'll start loading the data for this query. You call it like `loadQuery(~variables={...}, ~fetchPolicy=?, ~networkCacheConfig=?, ())`. As soon as you've called this function, the `queryRef` (first item of the tuple) will be populated, and you can pass that `queryRef` to `usePreloaded`.
+2. `loadQuery` - a function that'll start loading the data for this query. You call it like `loadQuery(~variables={...}, ~fetchPolicy=?, ~networkCacheConfig=?)`. As soon as you've called this function, the `queryRef` (first item of the tuple) will be populated, and you can pass that `queryRef` to `usePreloaded`.
 3. `disposeQuery` - a function that disposes the query reference manually. Calling this would turn `option(queryRef)` into `None`.
 
 So, the typical way to preload a query would be like this:
@@ -102,7 +101,7 @@ let make = (~userId) => {
   switch queryRef {
   | Some(queryRef) => <SomeComponent queryRef />
   | None =>
-    <button onClick={_ => loadQuery(~variables={id: userId}, ())}>
+    <button onClick={_ => loadQuery(~variables={id: userId})}>
       {React.string("See full user")}
     </button>
   }
@@ -280,8 +279,6 @@ As shown in the snippet above, `Query.use` is a React hook that dispatches your 
 
 ##### Parameters
 
-_Please note that this function must be called with an ending unit `()` if not all arguments are supplied._
-
 | Name                 | Type                                         | Required | Notes                                                                                     |
 | -------------------- | -------------------------------------------- | -------- | ----------------------------------------------------------------------------------------- |
 | `variables`          | `'variables`                                 | _Yes_    | Variables derived from the GraphQL operation. `unit` if no variables are defined.         |
@@ -300,15 +297,14 @@ Query.fetch(~environment, ~variables=(), ~onResult=res =>
   switch res {
   | Ok(res) => Js.log(res)
   | Error(_) => Js.log("Error")
-  },
-  ()
+  }
 )
 
 ```
 
 Please note though that `fetch` does not necessarily retain data in the Relay store, meaning it's really only suitable for data you only need once at a particular point in time. For refetching data, please check out [refetching and loading more data](refetching-and-loading-more-data).
 
-The results are delivered through a `Belt.Result.t` in the `onResult` callback.
+The results are delivered through a `RescriptCore.Result.t` in the `onResult` callback.
 
 > `fetch` uses Relay's `fetchQuery` under the hood, which you can [read more about here](https://relay.dev/docs/api-reference/fetch-query).
 
@@ -329,7 +325,7 @@ The same as `fetch`, but returns a promise instead of using a callback.
 Using it looks something like this:
 
 ```rescript
-Query.fetchPromised(~environment, ~variables=(), ())
+Query.fetchPromised(~environment, ~variables=())
   ->Js.Promise.then_(res => {
     Js.log(res)
     Js.Promise.resolve()
@@ -362,7 +358,7 @@ Pass this `queryRef` to the `Query.usePreloaded` hook to get data for the query.
 
 A function that starts loading the query, populating `queryRef`. Signature looks like this:
 
-`let loadQuery: (~variables: queryVariables, ~fetchPolicy: fetchPolicy=?, ~networkCacheConfig: networkCacheConfig=?, ()) => unit;`
+`let loadQuery: (~variables: queryVariables, ~fetchPolicy: fetchPolicy=?, ~networkCacheConfig: networkCacheConfig=?) => unit;`
 
 Call this as soon as possible to start your query.
 

--- a/rescript-relay-documentation/docs/migrating-to-v3.md
+++ b/rescript-relay-documentation/docs/migrating-to-v3.md
@@ -150,7 +150,7 @@ yarn rescript build
 Migrating is just about removing all object maker function usage and using regular records instead:
 
 ```rescript
-let doLogin = React.useCallback5(() => {
+let doLogin = React.useCallback(() => {
     let _ = login(
       // color2
       ~variables=LoginMutation.makeVariables(~username=state.username, ~password=state.password),

--- a/rescript-relay-documentation/docs/mutations.md
+++ b/rescript-relay-documentation/docs/mutations.md
@@ -43,8 +43,7 @@ let make = () => {
             id: todoItem.id,
             text: newText,
           },
-        },
-        (),
+        }
       )}>
     {React.string(isMutating ? "Updating..." : "Update")}
   </button>
@@ -118,17 +117,13 @@ let make = (~user) => {
   // This creates an id for the connection above with `minimumCommonFriends` as 10, and `onlineStatuses` at its default value (which is `[Idle]`).
   // Notice that we use `__id` from the user - that's because `makeConnectionId` needs to know the _owner_ for the connection you're looking for. It doesn't need the field of the connection, just the owner itself.
   let connectionId =
-    user.__id->UserFriendsList_user_graphql.makeConnectionId(
-      ~minimumCommonFriends=10,
-      (),
-    )
+    user.__id->UserFriendsList_user_graphql.makeConnectionId(~minimumCommonFriends=10)
 
   // This creates an id with both `minimumCommonFriends` and `onlineStatuses` having explicit values.
   let connectionId2 =
     user.__id->UserFriendsList_user_graphql.makeConnectionId(
       ~minimumCommonFriends=10,
-      ~onlineStatuses=[#Online, #Idle],
-      (),
+      ~onlineStatuses=[#Online, #Idle]
     )
 
   // We can then use these connection ID:s to either pass into the `connections: [ID!]!` argument of the declarative updater directives, or we can use them to imperatively pull out a connection from the store like this:
@@ -173,7 +168,6 @@ mutate(
       updatedTodoItem: Some({"id": todoItem.id, "text": todoItem.text}),
     }),
   },
-  (),
 )
 
 ```
@@ -289,8 +283,6 @@ A React hook for running and keeping track of the mutation. Returns a tuple of `
 
 ##### Parameters
 
-_Please note that this function must be called with an ending unit `()` if not all arguments are supplied._
-
 | Name                 | Type                                               | Required | Notes                                                                                                                                                                                                                                    |
 | -------------------- | -------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `variables`          | `'variables`                                       | _Yes_    | Variables derived from the GraphQL operation                                                                                                                                                                                             |
@@ -305,8 +297,6 @@ _Please note that this function must be called with an ending unit `()` if not a
 Commits the specified mutation to Relay and returns a `Disposable.t` that allow you to cancel listening for the mutation result if needed.
 
 ##### Parameters
-
-_Please note that this function must be called with an ending unit `()` if not all arguments are supplied._
 
 | Name                 | Type                                                       | Required | Notes                                                                                                                                                                                                                                                                                                                                                                                        |
 | -------------------- | ---------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/rescript-relay-documentation/docs/pagination.md
+++ b/rescript-relay-documentation/docs/pagination.md
@@ -77,10 +77,10 @@ let make = (~query) => {
       <h4 className="card-title"> {React.string("Recent Tickets")} </h4>
       <div>
         {tickets
-        ->Belt.Array.map(ticket => <SingleTicket key=ticket.id ticket=ticket.fragmentRefs />)
+        ->Array.map(ticket => <SingleTicket key=ticket.id ticket=ticket.fragmentRefs />)
         ->React.array}
         {hasNext
-          ? <button onClick={_ => loadNext(~count=2, ()) |> ignore} disabled=isLoadingNext>
+          ? <button onClick={_ => loadNext(~count=2)->RescriptRelay.Disposable.ignore} disabled=isLoadingNext>
               {React.string(isLoadingNext ? "Loading..." : "More")}
             </button>
           : React.null}
@@ -128,13 +128,13 @@ As shown above, `usePagination` provides helpers for paginating your fragment/co
 | Name                | Type                                                                                                      | Note                                                                 |
 | ------------------- | --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | `data`              | `'fragmentData`                                                                                           | The data as defined by the fragment.                                 |
-| `loadNext`          | `(~count: int, ~onComplete: option(Js.Exn.t) => unit=?, unit) => Disposable.t;`                           | A function for loading the next `count` nodes of the connection.     |
-| `loadPrevious`      | `(~count: int, ~onComplete: option(Js.Exn.t) => unit=?, unit) => Disposable.t;`                           | A function for loading the previous `count` nodes of the connection. |
+| `loadNext`          | `(~count: int, ~onComplete: option(Js.Exn.t) => unit=?) => Disposable.t;`                           | A function for loading the next `count` nodes of the connection.     |
+| `loadPrevious`      | `(~count: int, ~onComplete: option(Js.Exn.t) => unit=?) => Disposable.t;`                           | A function for loading the previous `count` nodes of the connection. |
 | `hasNext`           | `bool`                                                                                                    | Are there more nodes forward in the connection to fetch?             |
 | `hasPrevious`       | `bool`                                                                                                    | Are there more nodes backwards in the connection to fetch?           |
 | `isLoadingNext`     | `bool`                                                                                                    |                                                                      |
 | `isLoadingPrevious` | `bool`                                                                                                    |                                                                      |
-| `refetch`           | `(~variables: 'variables, ~fetchPolicy: fetchPolicy=?, ~onComplete: option(Js.Exn.t) => unit=?, unit) =>` | Refetch the entire connection with potentially new variables.        |
+| `refetch`           | `(~variables: 'variables, ~fetchPolicy: fetchPolicy=?, ~onComplete: option(Js.Exn.t) => unit=?) =>` | Refetch the entire connection with potentially new variables.        |
 
 ### `useBlockingPagination`
 

--- a/rescript-relay-documentation/docs/refetching-and-loading-more-data.md
+++ b/rescript-relay-documentation/docs/refetching-and-loading-more-data.md
@@ -52,7 +52,7 @@ let make = (~user) => {
         <button
           type_="button"
           onClick={_ =>
-            refetch(~variables=UserFragment.makeRefetchVariables(~bioMaxLength=Some(500), ()), ())}>
+            refetch(~variables=UserFragment.makeRefetchVariables(~bioMaxLength=Some(500)))}>
           {React.string("Show full bio text")}
         </button>
         <div> {React.string("Age: " ++ string_of_int(bio.age))} </div>
@@ -61,7 +61,7 @@ let make = (~user) => {
       <button
         type_="button"
         onClick={_ =>
-          refetch(~variables=UserFragment.makeRefetchVariables(~includeFullBio=Some(true), ()), ())}>
+          refetch(~variables=UserFragment.makeRefetchVariables(~includeFullBio=Some(true)))}>
         {React.string("Show bio")}
       </button>
     }}
@@ -85,9 +85,9 @@ Let's dive into `makeRefetchVariables`, because this can be a bit tricky to unde
 
 In the example above we have variables `$includeFullBio` and `$bioMaxLength`. Let's say this fragment gets rendered with `$includeFullBio = true` and `$bioMaxLength` not set yet.
 
-- If I want to refetch the fragment with `$includeFullBio` changed to `false`, I'd do `makeRefetchVariables(~includeFullBio=Some(false), ())`. `Some(false)` here tells Relay that "I want to change `$includeFullBio` in the refetch to `false`. Use the last value for all other variables".
-- If I want to set `$bioMaxLength` to something, I'd do `makeRefetchVariables(~bioMaxLength=Some(200), ())`. This tells Relay "set `bioMaxLength`, leave everything else as is".
-- If I have `bioMaxLength` set and I want to refetch data with it _not set at all_ (equivalent of passing `null`), I'd do `makeRefetchVariables(~bioMaxLength=None, ())`.
+- If I want to refetch the fragment with `$includeFullBio` changed to `false`, I'd do `makeRefetchVariables(~includeFullBio=Some(false))`. `Some(false)` here tells Relay that "I want to change `$includeFullBio` in the refetch to `false`. Use the last value for all other variables".
+- If I want to set `$bioMaxLength` to something, I'd do `makeRefetchVariables(~bioMaxLength=Some(200))`. This tells Relay "set `bioMaxLength`, leave everything else as is".
+- If I have `bioMaxLength` set and I want to refetch data with it _not set at all_ (equivalent of passing `null`), I'd do `makeRefetchVariables(~bioMaxLength=None)`.
 
 So, notice how `Some(value)` means "set this value", `None` means "unset this value", and leaving out the variable all together from `makeRefetchVariables` means "don't change this variable, reuse the last value".
 

--- a/rescript-relay-documentation/docs/subscriptions.md
+++ b/rescript-relay-documentation/docs/subscriptions.md
@@ -58,16 +58,15 @@ let subscriptionFunction: RescriptRelay.Network.subscribeFn = (config, variables
 
 let network = RescriptRelay.Network.makePromiseBased(
   ~fetchFunction=fetchQuery(token),
-  ~subscriptionFunction,
-  (),
+  ~subscriptionFunction
 )
 
 let store = {
   open RescriptRelay
-  Store.make(~source=RecordSource.make(), ())
+  Store.make(~source=RecordSource.make())
 }
 
-let environment = RescriptRelay.Environment.make(~network, ~store, ())
+let environment = RescriptRelay.Environment.make(~network, ~store)
 
 ```
 
@@ -112,11 +111,10 @@ module TicketStatusSubscription = %relay(
 @react.component
 let make = (~ticketId) => {
   let environment = RescriptRelay.useEnvironmentFromContext()
-  React.useEffect2(() => {
+  React.useEffect(() => {
     let subscription = TicketStatusSubscription.subscribe(
       ~environment,
-      ~variables={id: ticketId},
-      (),
+      ~variables={id: ticketId}
     )
     Some(() => RescriptRelay.Disposable.dispose(subscription))
   }, (ticketId, environment))

--- a/rescript-relay-documentation/docs/the-node-interface.md
+++ b/rescript-relay-documentation/docs/the-node-interface.md
@@ -34,8 +34,7 @@ let make = (~id: string) => {
   let queryData = Query.use(
     ~variables={
       id: id,
-    },
-    (),
+    }
   )
 
   {switch queryData.node {
@@ -91,8 +90,7 @@ let make = (~id: string) => {
   let queryData = Query.use(
     ~variables={
       id: id,
-    },
-    (),
+    }
   )
 
   {switch queryData.node {

--- a/rescript-relay-documentation/docs/tutorial/3-query-basics.md
+++ b/rescript-relay-documentation/docs/tutorial/3-query-basics.md
@@ -92,7 +92,7 @@ Turn back to the `Newsfeed` component and start by deleting the placeholder data
 ```rescript
 @react.component
 let make = () => {
-  let data = NewsfeedQuery.use(~variables=(), ())
+  let data = NewsfeedQuery.use(~variables=())
 
   switch data.topStory {
   | None => React.null
@@ -218,17 +218,17 @@ The object that `NewsfeedQuery.use` returns has the same shape as the query. For
 
 ```json
 {
-  topStory: {
-    title: "Local Yak Named Yak of the Year",
-    summary: "The annual Yak of the Year awards ceremony ...",
-    poster: {
-      name: "Baller Bovine Board",
-      profilePic: {
-        url: '/images/baller_bovine_board.jpg',
-      },
+  "topStory": {
+    "title": "Local Yak Named Yak of the Year",
+    "summary": "The annual Yak of the Year awards ceremony ...",
+    "poster": {
+      "name": "Baller Bovine Board",
+      "profilePic": {
+        "url": "/images/baller_bovine_board.jpg"
+      }
     },
-    thumbnail: {
-      url: '/images/max_the_yak.jpg',
+    "thumbnail": {
+      "url": "/images/max_the_yak.jpg"
     }
   }
 }

--- a/rescript-relay-documentation/docs/tutorial/4-fragments.md
+++ b/rescript-relay-documentation/docs/tutorial/4-fragments.md
@@ -185,7 +185,7 @@ Since `Story.res` now expects a fragment key, we change the `make` funtion of `N
 ```rescript
 @react.component
 let make = () => {
-  let data = NewsfeedQuery.use(~variables=(), ())
+  let data = NewsfeedQuery.use(~variables=())
 
   switch data.topStory {
   | None => React.null

--- a/rescript-relay-documentation/docs/tutorial/5-arrays-and-lists.md
+++ b/rescript-relay-documentation/docs/tutorial/5-arrays-and-lists.md
@@ -68,7 +68,7 @@ In the `Newsfeed` component, `data` no longer has a field `topStory`, but now in
 ```rescript
 @react.component
 let make = () => {
-  let data = NewsfeedQuery.use(~variables=(), ())
+  let data = NewsfeedQuery.use(~variables=())
 
   switch data.topStories {
   | None => React.null
@@ -110,7 +110,7 @@ module NewsfeedQuery = %relay(`
 
 @react.component
 let make = () => {
-  let {topStories} = NewsfeedQuery.use(~variables=(), ())
+  let {topStories} = NewsfeedQuery.use(~variables=())
 
   switch topStories {
   | None => React.null

--- a/rescript-relay-documentation/docs/tutorial/6-queries-for-interaction.md
+++ b/rescript-relay-documentation/docs/tutorial/6-queries-for-interaction.md
@@ -194,7 +194,7 @@ We’ll add a new prop to our component and pass its value in there:
 // change-line
 let make = (~posterID) => {
   // change-line
-  let data = HovercardQuery.use(~variables={posterID: posterID}, ())
+  let data = HovercardQuery.use(~variables={posterID: posterID})
   <div className="posterHovercard">
     {switch data.node {
     | None => React.null
@@ -293,7 +293,7 @@ As a reminder, this is the `PosterDetailsHovercardContents` component that curre
 ```rescript
 @react.component
 let make = (~posterID) => {
-  let data = HovercardQuery.use(~variables={posterID: posterID}, ())
+  let data = HovercardQuery.use(~variables={posterID: posterID})
   <div className="posterHovercard">
     {switch data.node {
     | None => React.null
@@ -383,7 +383,7 @@ let make = (~poster) => {
       <div className="byline__name"> {name->React.string} </div>
       <Hovercard
         // change-line
-        targetRef={hoverRef} onBeginHover={_ => loadHoverCardQuery(~variables={posterID: id}, ())}>
+        targetRef={hoverRef} onBeginHover={_ => loadHoverCardQuery(~variables={posterID: id})}>
         {switch hovercardQueryRef {
         | None => React.null
         | Some(queryRef) => <PosterDetailsHovercardContents queryRef />

--- a/rescript-relay-documentation/docs/tutorial/8-refetchable-fragments.md
+++ b/rescript-relay-documentation/docs/tutorial/8-refetchable-fragments.md
@@ -224,7 +224,7 @@ let make = (~viewer) => {
     | None => React.null
     | Some(contacts) =>
       contacts
-      ->Array.keepMap(x => x)
+      ->Array.keepSome
       ->Array.map(contact => <ContactRow key={contact.id} contact={contact.fragmentRefs} />)
       ->React.array
     }}

--- a/rescript-relay-documentation/docs/tutorial/8-refetchable-fragments.md
+++ b/rescript-relay-documentation/docs/tutorial/8-refetchable-fragments.md
@@ -172,8 +172,8 @@ let make = (~viewer) => {
   // change
   let onSearchStringChanged = value => {
     setSearchString(_ => value)
-    let variables = Fragment.makeRefetchVariables(~search=Some(value), ())
-    refetch(~variables, ())->RescriptRelay.Disposable.ignore
+    let variables = Fragment.makeRefetchVariables(~search=Some(value))
+    refetch(~variables)->RescriptRelay.Disposable.ignore
   }
   // end-change
 
@@ -210,8 +210,8 @@ let make = (~viewer) => {
     setSearchString(_ => value)
     // change
     startTransition(() => {
-      let variables = Fragment.makeRefetchVariables(~search=Some(value), ())
-      refetch(~variables, ())->RescriptRelay.Disposable.ignore
+      let variables = Fragment.makeRefetchVariables(~search=Some(value))
+      refetch(~variables)->RescriptRelay.Disposable.ignore
     })
     // end-change
   }
@@ -224,8 +224,8 @@ let make = (~viewer) => {
     | None => React.null
     | Some(contacts) =>
       contacts
-      ->Belt.Array.keepMap(x => x)
-      ->Belt.Array.map(contact => <ContactRow key={contact.id} contact={contact.fragmentRefs} />)
+      ->Array.keepMap(x => x)
+      ->Array.map(contact => <ContactRow key={contact.id} contact={contact.fragmentRefs} />)
       ->React.array
     }}
   </Card>

--- a/rescript-relay-documentation/docs/tutorial/9-connections-pagination.md
+++ b/rescript-relay-documentation/docs/tutorial/9-connections-pagination.md
@@ -260,7 +260,7 @@ to
 
 ```rescript
 let {data, loadNext} = Fragment.usePagination(story)
-let onLoadMore = () => loadNext(~count=3, ())->RescriptRelay.Disposable.ignore
+let onLoadMore = () => loadNext(~count=3)->RescriptRelay.Disposable.ignore
 ```
 
 and pass `onLoadMore` to the button: `<LoadMoreCommentsButton onClick=onLoadMore />`
@@ -288,7 +288,7 @@ let make = (~story) => {
   // change
   let onLoadMore = () =>
     startTransition(() => {
-      loadNext(~count=3, ())->ignore
+      loadNext(~count=3)->RescriptRelay.Disposable.ignore
     })
   // end-change
   
@@ -357,7 +357,7 @@ We’ve replaced `topStories` with `viewer`’s `newsfeedStories`, adding a `fir
 ```rescript
 @react.component
 let make = () => {
-  let {viewer} = NewsfeedQuery.use(~variables=(), ())
+  let {viewer} = NewsfeedQuery.use(~variables=())
 
   switch viewer {
   | None => React.null
@@ -404,7 +404,7 @@ let make = (~viewer as viewerRef) => {
 
   <>
     {stories
-    ->Belt.Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
+    ->Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
     ->React.array}
   </>
 }
@@ -424,7 +424,7 @@ module NewsfeedQuery = %relay(`
 
 @react.component
 let make = () => {
-  let {viewer} = NewsfeedQuery.use(~variables=(), ())
+  let {viewer} = NewsfeedQuery.use(~variables=())
 
   <div className="newsfeed">
     {switch viewer {
@@ -480,7 +480,7 @@ let make = (~viewer as viewerRef) => {
 
   <>
     {stories
-    ->Belt.Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
+    ->Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
     ->React.array}
   </>
 }
@@ -498,11 +498,11 @@ let make = (~viewer as viewerRef) => {
   let stories = Fragment.getConnectionNodes(data.newsfeedStories)
 
   // change-line
-  let onEndReached = () => loadNext(~count=3, ())->ignore
+  let onEndReached = () => loadNext(~count=3)->RescriptRelay.Disposable.ignore
 
   <>
     {stories
-    ->Belt.Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
+    ->Array.map(story => <Story key={story.id} story={story.fragmentRefs} />)
     ->React.array}
     // change-line
     <InfiniteScrollTrigger onEndReached hasNext isLoadingNext />

--- a/rescript-relay-documentation/docs/unions.md
+++ b/rescript-relay-documentation/docs/unions.md
@@ -58,7 +58,7 @@ module Query = %relay(
 
 @react.component
 let make = (~roomId) => {
-  let queryData = Query.use(~variables={roomId: roomId}, ())
+  let queryData = Query.use(~variables={roomId: roomId})
 
   switch queryData.roomOwner {
   | Some(roomOwner) =>

--- a/rescript-relay-documentation/docs/using-fragments.md
+++ b/rescript-relay-documentation/docs/using-fragments.md
@@ -117,8 +117,7 @@ let make = (~userId) => {
   let queryData = Query.use(
     ~variables={
       userId: userId,
-    },
-    (),
+    }
   )
 
   switch queryData.userById {
@@ -237,7 +236,6 @@ let logPurchase = user => {
   SomeLoggingService.log(
     ~customerId=userId.customerId,
     ~someOtherMetaDataProp=userId.someOtherMetaDataProp,
-    (),
   )
 }
 

--- a/rescript-relay-documentation/docs/variables.md
+++ b/rescript-relay-documentation/docs/variables.md
@@ -26,10 +26,10 @@ module Mutation = %relay(`
 `)
 
 // All optional variables in this operation can now be `null`, which will be preserved and sent to your server.
-Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.null}, ())
+Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.null})
 
 // Or if you want to send a value:
-Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.Null.return("some-avatar-url")}, ())
+Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.Null.return("some-avatar-url")})
 ```
 
 This works for:

--- a/rescript-relay-documentation/docs/variables.md
+++ b/rescript-relay-documentation/docs/variables.md
@@ -26,10 +26,10 @@ module Mutation = %relay(`
 `)
 
 // All optional variables in this operation can now be `null`, which will be preserved and sent to your server.
-Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.null})
+Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Null})
 
 // Or if you want to send a value:
-Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Js.Null.return("some-avatar-url")})
+Mutation.commitMutation(~environment=RelayEnvironment.environment, ~variables={avatarUrl: Value("some-avatar-url")})
 ```
 
 This works for:


### PR DESCRIPTION
Ready to merge when `v3` release is published (not rc).

Here is what changed:
- updated getting started with new required package versions
- include how to setup rescript.json on Windows in getting started
- remove trailing units
- stop using Belt module in examples and assume RescriptCore is globally open
- use non-deprecated React hooks in examples (`useCallback5` -> `useCallback`)
- stop using `makeVariables` in examples and remove it from docs