### PR TITLE
[Docs] Fix inconsistency in names in input union example in 3.0 release notes

### DIFF
--- a/rescript-relay-documentation/blog/2024-08-06-rescript-relay-3.0.0-released.md
+++ b/rescript-relay-documentation/blog/2024-08-06-rescript-relay-3.0.0-released.md
@@ -92,16 +92,19 @@ This will produce the following variant for `location`:
 
 ```rescript
 type input_ByAddress = {
+  streetAddress: string,
+  postalCode: string,
   city: string,
 }
 
-type input_ByLoc = {
+type input_ByCoordinates = {
   lat: float,
+  lng: float,
 }
 
 type input_Location =
 | ByAddress(input_ByAddress)
-| ByLoc(input_ByLoc)
+| ByCoordinates(input_ByCoordinates)
 | ById(string)
 ```
 


### PR DESCRIPTION
Small drive-by fix I noticed in the examples while reading the release notes.

Looks like a great release—the community is very lucky to have you!