### PR TITLE
Minor docs page fix

### DIFF
--- a/rescript-relay-documentation/docs/introduction.md
+++ b/rescript-relay-documentation/docs/introduction.md
@@ -1,7 +1,0 @@
----
-id: introduction
-title: Introduction
-sidebar_label: Introduction
----
-
-_WIP_.

--- a/rescript-relay-documentation/docusaurus.config.js
+++ b/rescript-relay-documentation/docusaurus.config.js
@@ -72,7 +72,7 @@ module.exports = {
           items: [
             {
               label: "Docs",
-              to: "docs/introduction",
+              to: "docs/start-here",
             },
           ],
         },


### PR DESCRIPTION
Hey @zth! 

Was clicking around the rescript-relay website and found what i think might be an old link in the footer.

- Fixed "broken" link footer to point to docs introduction
- Removed introduction page that was marked as "WIP" (but I don't think it's intended to be done?)